### PR TITLE
Significantly improved blogs fetching performance

### DIFF
--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
@@ -34,7 +34,7 @@ public class BloggersDataUpdater {
             .filter(entry -> entry.getRss().length() > 0)
             .collect(Collectors.toList());
         UpdateSummary updateSummary = new UpdateSummary(entries.size());
-        entries.stream().forEach(entry -> updateSingleEntry(entry, updateSummary));
+        entries.parallelStream().forEach(entry -> updateSingleEntry(entry, updateSummary));
         log.info("Bloggers Data updated: totalRecordsInFile={}, updatedRecords={}, newRecords={}",
             updateSummary.numberOfEntries,
             updateSummary.updatedEntries, updateSummary.createdEntries);


### PR DESCRIPTION
I noticed that blogs are fetched by fire-forget (stream foreach) so why not parallelize it?
This improves fetching time by an order of magnitude.
