### PR TITLE
Improved Liquibase logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     // Database related
     compile "org.postgresql:postgresql:9.4.1210.jre7"
     compile 'org.liquibase:liquibase-core:3.4.2'
+    compile 'com.mattbertolini:liquibase-slf4j:2.0.0'
 
     //Kafka
     compile "com.typesafe.akka:akka-stream-kafka_$scalaVersion:0.12"


### PR DESCRIPTION
By default Liquibase uses _stderr_ to print its logging statements. I have added a [dependency](https://github.com/mattbertolini/liquibase-slf4j) to the extension forcing Liquibase to use application configured logger instead.