### PR TITLE
Fixed NPE on application boot when the database contains no blog posts

### DIFF
--- a/src/main/java/com/jvm_bloggers/core/InitialBlogDataPopulationTrigger.java
+++ b/src/main/java/com/jvm_bloggers/core/InitialBlogDataPopulationTrigger.java
@@ -10,9 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Initializes database with bloggers and posts data if database is empty.
@@ -31,7 +31,7 @@ public class InitialBlogDataPopulationTrigger {
     private final BloggersDataFetchingScheduler bloggersDataFetchingScheduler;
     private final BlogPostsFetchingScheduler blogPostsFetchingScheduler;
 
-    @PostConstruct
+    @EventListener(ContextRefreshedEvent.class)
     public void initializeDatabaseWithBlogDataIfEmpty() {
 
         if (blogRepository.count() == 0) {


### PR DESCRIPTION
This is the fix for _NPE_ which revealed itself in #271. Database population trigger was delayed until Spring application context is fully initialized to prevent _NPE_ race condition in [`SpringApplicationContext`](https://github.com/jvm-bloggers/jvm-bloggers/blob/17aabd22deeb5da75864a6dd102a54708cf42bf5/src/main/java/com/jvm_bloggers/SpringApplicationContext.java#L18) component.