### PR TITLE
Allowing only single values for http headers.

### DIFF
--- a/src/main/java/com/jvm_bloggers/core/data_fetching/http/ProtocolSwitchingAwareConnectionRedirectHandler.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/http/ProtocolSwitchingAwareConnectionRedirectHandler.java
@@ -8,13 +8,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import net.jcip.annotations.ThreadSafe;
+
 import org.apache.commons.collections4.MapUtils;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.List;
 import java.util.Map;
 
 
@@ -58,7 +58,7 @@ public class ProtocolSwitchingAwareConnectionRedirectHandler {
      *                                   {@link #REDIRECT_LIMIT redirects limit}
      */
     public HttpURLConnection handle(@NonNull URLConnection urlConnection,
-                                    Map<String, List<String>> headers) throws IOException {
+                                    Map<String, String> headers) throws IOException {
 
         HttpURLConnection conn = (HttpURLConnection) urlConnection;
         int redirectCounter = 0;
@@ -92,7 +92,7 @@ public class ProtocolSwitchingAwareConnectionRedirectHandler {
         return redirectCounter;
     }
 
-    private void setupConnection(HttpURLConnection conn, Map<String, List<String>> headers) {
+    private void setupConnection(HttpURLConnection conn, Map<String, String> headers) {
         conn.setConnectTimeout(DEFAULT_TIMEOUT);
         conn.setReadTimeout(DEFAULT_TIMEOUT);
         // handle redirects within the same protocol
@@ -102,12 +102,9 @@ public class ProtocolSwitchingAwareConnectionRedirectHandler {
         }
     }
 
-    private void setupHeaders(HttpURLConnection conn, Map<String, List<String>> headers) {
-        headers.entrySet().forEach(header -> {
-            header.getValue().forEach(value -> {
-                conn.setRequestProperty(header.getKey(), value);
-            });
-        });
+    private void setupHeaders(HttpURLConnection conn, Map<String, String> headers) {
+        headers.entrySet()
+            .forEach(header -> conn.setRequestProperty(header.getKey(), header.getValue()));
     }
 
     private HttpURLConnection handleRedirect(HttpURLConnection conn) throws IOException {

--- a/src/main/java/com/jvm_bloggers/core/rss/SyndFeedProducer.java
+++ b/src/main/java/com/jvm_bloggers/core/rss/SyndFeedProducer.java
@@ -1,6 +1,5 @@
 package com.jvm_bloggers.core.rss;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.jvm_bloggers.core.data_fetching.http.ProtocolSwitchingAwareConnectionRedirectHandler;
 import com.jvm_bloggers.core.utils.Validators;
@@ -19,7 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -37,8 +35,8 @@ public class SyndFeedProducer {
         URLConnection urlConnection = null;
         try {
             urlConnection = new URL(rssUrl).openConnection();
-            final Map<String, List<String>> headers =
-                ImmutableMap.of("User-Agent", ImmutableList.of(FAKE_USER_AGENT));
+            final Map<String, String> headers =
+                ImmutableMap.of("User-Agent", FAKE_USER_AGENT);
             urlConnection = redirectHandler.handle(urlConnection, headers);
             @Cleanup
             final InputStream inputStream = urlConnection.getInputStream();

--- a/src/test/groovy/com/jvm_bloggers/core/data_fetching/http/ProtocolSwitchingAwareConnectionRedirectHandlerSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/data_fetching/http/ProtocolSwitchingAwareConnectionRedirectHandlerSpec.groovy
@@ -8,7 +8,7 @@ import static ProtocolSwitchingAwareConnectionRedirectHandler.LOCATION_HEADER
 
 class ProtocolSwitchingAwareConnectionRedirectHandlerSpec extends Specification {
 
-    static final REQUEST_HEADERS = ["header": ["value 1", "value 2"]]
+    static final REQUEST_HEADERS = ["header": "value 1"]
 
     final HttpURLConnection httpConnection = Mock();
 
@@ -65,7 +65,6 @@ class ProtocolSwitchingAwareConnectionRedirectHandlerSpec extends Specification 
     private def commonInteractions() {
         with(httpConnection) {
             1 * setRequestProperty("header", "value 1")
-            1 * setRequestProperty("header", "value 2")
             1 * setInstanceFollowRedirects(true)
             1 * setReadTimeout(DEFAULT_TIMEOUT)
             1 * setConnectTimeout(DEFAULT_TIMEOUT)


### PR DESCRIPTION
According to the [documentation](https://docs.oracle.com/javase/8/docs/api/java/net/URLConnection.html#setRequestProperty-java.lang.String-java.lang.String-) current approach would only set last value passed. If we really need multi value headers we should merge them into one but I don't think we need it. 