### PR TITLE
Support for contributors fetching thought GitHub API. Fix #288

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ ext {
     wicketVersion = '7.5.0'
     akkaVersion = '2.4.12'
     scalaVersion = "2.11"
+    jacksonVersion = '2.24'
 }
 
 dependencies {
@@ -55,7 +56,6 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator"
     compile 'com.github.ulisesbocchio:jasypt-spring-boot:1.9'
     compile 'org.springframework.boot:spring-boot-devtools'
-
 
     // Logic
     compile "com.typesafe.akka:akka-actor_$scalaVersion:$akkaVersion"
@@ -76,7 +76,8 @@ dependencies {
     compile 'com.google.guava:guava:21.0'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.antlr:ST4:4.0.8'
-    compile 'org.glassfish.jersey.core:jersey-client:2.24'
+    compile "org.glassfish.jersey.core:jersey-client:$jacksonVersion"
+    compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jacksonVersion"
     compile 'net.jcip:jcip-annotations:1.0'
     compile 'org.objenesis:objenesis:2.4'
     compile 'commons-validator:commons-validator:1.5.1'

--- a/src/main/java/com/jvm_bloggers/GithubClient.java
+++ b/src/main/java/com/jvm_bloggers/GithubClient.java
@@ -1,0 +1,17 @@
+package com.jvm_bloggers;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD,
+    ElementType.METHOD,
+    ElementType.TYPE,
+    ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface GithubClient {
+}

--- a/src/main/java/com/jvm_bloggers/JvmBloggersConfiguration.java
+++ b/src/main/java/com/jvm_bloggers/JvmBloggersConfiguration.java
@@ -2,8 +2,13 @@ package com.jvm_bloggers;
 
 
 import akka.actor.ActorSystem;
+
+import com.jvm_bloggers.core.github.GithubAuthenticationFilter;
+import com.jvm_bloggers.core.github.GithubProperties;
+
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.guava.GuavaCacheManager;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +21,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
 @Configuration
+@EnableConfigurationProperties(GithubProperties.class)
 public class JvmBloggersConfiguration {
 
     @Bean
@@ -24,6 +30,7 @@ public class JvmBloggersConfiguration {
     }
 
     @Bean
+    @MailingClient
     public Client getMailingRestClient(@Value("${mailing.apiKey}") String malingApiKey) {
         final Client client = ClientBuilder.newClient();
 
@@ -38,8 +45,19 @@ public class JvmBloggersConfiguration {
     }
 
     @Bean
-    public CacheManager cacheManager() {
-        return new GuavaCacheManager();
+    @GithubClient
+    public Client getGithubRestClient(GithubAuthenticationFilter githubAuthenticationFilter) {
+        final Client client = ClientBuilder.newClient();
+        client.register(githubAuthenticationFilter);
+
+        return client;
+    }
+
+    @Bean
+    public CacheManager cacheManager(@Value("${cache.spec}") String cacheSpec) {
+        GuavaCacheManager guavaCacheManager = new GuavaCacheManager();
+        guavaCacheManager.setCacheSpecification(cacheSpec);
+        return guavaCacheManager;
     }
 
     @Bean

--- a/src/main/java/com/jvm_bloggers/MailingClient.java
+++ b/src/main/java/com/jvm_bloggers/MailingClient.java
@@ -1,0 +1,17 @@
+package com.jvm_bloggers;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD,
+    ElementType.METHOD,
+    ElementType.TYPE,
+    ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface MailingClient {
+}

--- a/src/main/java/com/jvm_bloggers/core/github/ContributorsService.java
+++ b/src/main/java/com/jvm_bloggers/core/github/ContributorsService.java
@@ -1,0 +1,58 @@
+package com.jvm_bloggers.core.github;
+
+import com.jvm_bloggers.GithubClient;
+import com.jvm_bloggers.entities.github.Contributor;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+
+@Service
+public class ContributorsService {
+
+    private static final GenericType<List<Contributor>> CONTRIBUTORS_LIST_TYPE =
+        new GenericType<List<Contributor>>() {
+        };
+
+    private final Client client;
+    private final GithubProperties properties;
+
+    public ContributorsService(@GithubClient Client client, GithubProperties githubProperties) {
+        this.client = client;
+        this.properties = githubProperties;
+    }
+
+    @Cacheable("contributors")
+    public List<Contributor> fetchContributors() {
+        WebTarget target = client
+            .target("{api_url}/repos/{org}/{repo}/contributors")
+            .resolveTemplate("api_url", properties.getApiUrl(), false)
+            .resolveTemplate("org", properties.getOrg(), false)
+            .resolveTemplate("repo", properties.getRepo(), false);
+
+        return traversePages(target, new ArrayList<>());
+    }
+
+    private List<Contributor> traversePages(WebTarget target, List<Contributor> aggregate) {
+        Response response = target.request().get();
+
+        List<Contributor> contributors = response.readEntity(CONTRIBUTORS_LIST_TYPE);
+        aggregate.addAll(contributors);
+
+        Link next = response.getLink("next");
+        if (next == null) {
+            return aggregate;
+        } else {
+            WebTarget nextPage = client.target(next);
+            return traversePages(nextPage, aggregate);
+        }
+    }
+}

--- a/src/main/java/com/jvm_bloggers/core/github/GithubAuthenticationFilter.java
+++ b/src/main/java/com/jvm_bloggers/core/github/GithubAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.jvm_bloggers.core.github;
 
+import lombok.RequiredArgsConstructor;
+
 import org.apache.wicket.util.string.Strings;
 import org.springframework.stereotype.Component;
 
@@ -8,8 +10,6 @@ import java.io.IOException;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.HttpHeaders;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/jvm_bloggers/core/github/GithubAuthenticationFilter.java
+++ b/src/main/java/com/jvm_bloggers/core/github/GithubAuthenticationFilter.java
@@ -9,14 +9,13 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.HttpHeaders;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class GithubAuthenticationFilter implements ClientRequestFilter {
 
     private final GithubProperties githubProperties;
-
-    public GithubAuthenticationFilter(GithubProperties githubProperties) {
-        this.githubProperties = githubProperties;
-    }
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {

--- a/src/main/java/com/jvm_bloggers/core/github/GithubAuthenticationFilter.java
+++ b/src/main/java/com/jvm_bloggers/core/github/GithubAuthenticationFilter.java
@@ -1,0 +1,29 @@
+package com.jvm_bloggers.core.github;
+
+import org.apache.wicket.util.string.Strings;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+
+@Component
+public class GithubAuthenticationFilter implements ClientRequestFilter {
+
+    private final GithubProperties githubProperties;
+
+    public GithubAuthenticationFilter(GithubProperties githubProperties) {
+        this.githubProperties = githubProperties;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        if (!Strings.isEmpty(githubProperties.getToken())) {
+            requestContext
+                .getHeaders()
+                .putSingle(HttpHeaders.AUTHORIZATION, "token " + githubProperties.getToken());
+        }
+    }
+}

--- a/src/main/java/com/jvm_bloggers/core/github/GithubProperties.java
+++ b/src/main/java/com/jvm_bloggers/core/github/GithubProperties.java
@@ -1,0 +1,23 @@
+package com.jvm_bloggers.core.github;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Validated
+@ConfigurationProperties("github.api")
+public class GithubProperties {
+
+    private String token;
+    @NotNull
+    private String apiUrl;
+    @NotNull
+    private String org;
+    @NotNull
+    private String repo;
+
+}

--- a/src/main/java/com/jvm_bloggers/core/mailing/sender/MailgunSender.java
+++ b/src/main/java/com/jvm_bloggers/core/mailing/sender/MailgunSender.java
@@ -2,6 +2,8 @@ package com.jvm_bloggers.core.mailing.sender;
 
 
 import com.google.common.util.concurrent.RateLimiter;
+import com.jvm_bloggers.MailingClient;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,7 +35,7 @@ class MailgunSender implements MailSender {
     }
 
     @Autowired
-    public MailgunSender(Client mailingRestClient,
+    public MailgunSender(@MailingClient Client mailingRestClient,
                          @Value("${mailing.throttleDelayInSeconds}") long throttleTimeInSeconds) {
         this.mailingRestClient = mailingRestClient;
         this.rateLimiter = RateLimiter.create(1.0 / throttleTimeInSeconds);

--- a/src/main/java/com/jvm_bloggers/entities/github/Contributor.java
+++ b/src/main/java/com/jvm_bloggers/entities/github/Contributor.java
@@ -1,0 +1,20 @@
+package com.jvm_bloggers.entities.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Contributor implements Serializable {
+
+    private String login;
+    @JsonProperty("html_url")
+    private String profilePage;
+    @JsonProperty("avatar_url")
+    private String avatarUrl;
+    private int contributions;
+}

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/common_layout/HeaderFrontend.html
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/common_layout/HeaderFrontend.html
@@ -33,6 +33,7 @@
                     <ul class="rd-navbar-nav">
                         <li><a href="/">Home <small>Let`s start</small></a></li>
                         <li><a wicket:id="allIssues">Archiwum</a></li>
+                        <li><a wicket:id="contributors">Autorzy</a></li>
                         <li><a href="https://github.com/jvm-bloggers/jvm-bloggers/" target="_blank">GitHub</a></li>
                         <li><a href="/">About</a></li>
                     </ul>

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/common_layout/HeaderFrontend.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/common_layout/HeaderFrontend.java
@@ -2,6 +2,8 @@ package com.jvm_bloggers.frontend.public_area.common_layout;
 
 import com.googlecode.wicket.jquery.ui.markup.html.link.BookmarkablePageLink;
 import com.jvm_bloggers.frontend.public_area.all_issues.AllIssuesPage;
+import com.jvm_bloggers.frontend.public_area.contributors.ContributorsPage;
+
 import org.apache.wicket.markup.html.panel.Panel;
 
 public class HeaderFrontend extends Panel {
@@ -9,5 +11,6 @@ public class HeaderFrontend extends Panel {
     public HeaderFrontend(String id) {
         super(id);
         add(new BookmarkablePageLink<>("allIssues", AllIssuesPage.class));
+        add(new BookmarkablePageLink<>("contributors", ContributorsPage.class));
     }
 }

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorDetails.html
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorDetails.html
@@ -1,0 +1,18 @@
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.5-strict.dtd">
+
+<body>
+
+<wicket:panel>
+    <a wicket:id="avatarLink" class="hover-img">
+        <img wicket:id="avatar"/>
+    </a>
+    <div class="caption">
+        <strong>
+            <a wicket:id="link"></a>
+        </strong>
+        <p class="small text-darker lh-21">Zmian: <span wicket:id="contributions"></span></p>
+    </div>
+</wicket:panel>
+
+</body>
+</html>

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorDetails.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorDetails.java
@@ -1,0 +1,26 @@
+package com.jvm_bloggers.frontend.public_area.contributors;
+
+import com.jvm_bloggers.entities.github.Contributor;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.image.ExternalImage;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+
+public class ContributorDetails extends Panel {
+
+    public ContributorDetails(String id, IModel<Contributor> model) {
+        super(id);
+        Contributor contributor = model.getObject();
+
+        ExternalImage avatar = new ExternalImage("avatar", contributor.getAvatarUrl());
+        ExternalLink avatarLink =
+            new ExternalLink("avatarLink", contributor.getProfilePage());
+        avatarLink.add(avatar);
+        add(avatarLink);
+
+        add(new ExternalLink("link", contributor.getProfilePage(), contributor.getLogin()));
+        add(new Label("contributions", contributor.getContributions()));
+    }
+}

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorsPage.html
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorsPage.html
@@ -1,0 +1,16 @@
+<html xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.5-strict.dtd">
+
+<body>
+
+<wicket:extend>
+    <h1>Autorzy:</h1>
+    <div class="meta"></div>
+    <div class="row flow-offset-1">
+        <div wicket:id="contributorsList" class="col-sm-6 col-md-4">
+            <div wicket:id="contributorDetails" class="thumbnail thumbnail-shop-catalog thumbnail-4 border-light"/>
+        </div>
+    </div>
+</wicket:extend>
+
+</body>
+</html>

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorsPage.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/contributors/ContributorsPage.java
@@ -1,0 +1,34 @@
+package com.jvm_bloggers.frontend.public_area.contributors;
+
+import com.jvm_bloggers.core.github.ContributorsService;
+import com.jvm_bloggers.entities.github.Contributor;
+import com.jvm_bloggers.frontend.public_area.AbstractFrontendPage;
+
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.wicketstuff.annotation.mount.MountPath;
+
+import java.util.List;
+
+@MountPath("contributors")
+public class ContributorsPage extends AbstractFrontendPage {
+
+    private static final String CONTRIBUTORS_LIST_ID = "contributorsList";
+
+    @SpringBean
+    private ContributorsService contributorsService;
+
+    public ContributorsPage() {
+        List<Contributor> contributors = contributorsService.fetchContributors();
+        ListView<Contributor> listView =
+            new ListView<Contributor>(CONTRIBUTORS_LIST_ID, contributors) {
+
+                @Override
+                protected void populateItem(ListItem<Contributor> item) {
+                    item.add(new ContributorDetails("contributorDetails", item.getModel()));
+                }
+            };
+        add(listView);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,7 @@ youtube.data.file.url: https://raw.githubusercontent.com/jvm-bloggers/jvm-blogge
 generated.rss.entries.limit: 50
 items.pagination.size: 15
 max.new.post.age.days: 30
+cache.spec: expireAfterWrite=1d
 
 application.baseUrl: http://jvm-bloggers.com
 application.issueUrl: ${application.baseUrl}/issue/
@@ -29,5 +30,11 @@ logging.level.com.jvm_bloggers: INFO
 
 scheduler.fetch-bloggers-data: 0 0 7,9,11,13,15,17,19,21,23 * * *
 scheduler.fetch-rss-for-new-blogs: 0 30 * * * *
-scheduler.publish-new-issue: 0 0 12 * * FRI
+scheduler.publish-new-issue: 0 0 13 * * FRI
 scheduler.send-email: 240000 # 4 minutes
+
+github.api:
+  token: #Personal access tokens can be created under https://github.com/settings/tokens
+  apiUrl: https://api.github.com
+  org: jvm-bloggers
+  repo: jvm-bloggers

--- a/src/test/groovy/com/jvm_bloggers/core/github/ContributorsServiceSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/github/ContributorsServiceSpec.groovy
@@ -1,0 +1,91 @@
+package com.jvm_bloggers.core.github
+
+import com.jvm_bloggers.entities.github.Contributor
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.ws.rs.client.Client
+import javax.ws.rs.client.Invocation
+import javax.ws.rs.client.WebTarget
+import javax.ws.rs.core.Link
+import javax.ws.rs.core.Response
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class ContributorsServiceSpec extends Specification {
+
+    public static final String ORG = "ORG"
+    public static final String REPO = "REPO"
+    public static final String URL = "URL"
+
+    @Subject
+    ContributorsService testObj
+
+    Client client = Mock()
+    GithubProperties properties = new GithubProperties()
+
+    def setup() {
+        properties.setOrg(ORG)
+        properties.setRepo(REPO)
+        properties.setApiUrl(URL)
+        testObj = new ContributorsService(client, properties)
+    }
+
+    def "Should fetch contributors from a single page"() {
+        given:
+            WebTarget target = Mock()
+            client.target(_) >> target
+            target.resolveTemplate(_, _, _) >> target
+
+            Response response = Mock(Response)
+            Contributor contributor1 = Mock(Contributor)
+            Contributor contributor2 = Mock(Contributor)
+            response.readEntity(_) >> Arrays.asList(contributor1, contributor2)
+
+            target.request() >> Stub(Invocation.Builder) {
+                get() >> response
+            }
+
+        when:
+            List<Contributor> actual = testObj.fetchContributors()
+
+        then:
+            assertThat(actual).containsOnly(contributor1, contributor2)
+    }
+
+    def "Should fetch contributors from multiple pages"() {
+        given:
+            WebTarget target = Mock()
+            client.target(_ as String) >> target
+            target.resolveTemplate(_, _, _) >> target
+
+            Response response = Mock(Response)
+            Contributor contributor1 = Mock(Contributor)
+            Contributor contributor2 = Mock(Contributor)
+            response.readEntity(_) >> Arrays.asList(contributor1, contributor2)
+
+            Link link = Mock(Link)
+            response.getLink("next") >> link
+
+            target.request() >> Stub(Invocation.Builder) {
+                get() >> response
+            }
+
+            WebTarget secondPageTarget = Mock(WebTarget)
+            client.target(link) >> secondPageTarget
+
+            Response secondPageResponse = Mock(Response)
+            Contributor contributor3 = Mock(Contributor)
+            secondPageResponse.readEntity(_) >> Arrays.asList(contributor3)
+
+            secondPageTarget.request() >> Stub(Invocation.Builder) {
+                get() >> secondPageResponse
+            }
+
+        when:
+            List<Contributor> actual = testObj.fetchContributors()
+
+        then:
+            assertThat(actual).containsOnly(contributor1, contributor2, contributor3)
+    }
+}

--- a/src/test/groovy/com/jvm_bloggers/core/github/GithubAuthenticationFilterSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/github/GithubAuthenticationFilterSpec.groovy
@@ -1,0 +1,62 @@
+package com.jvm_bloggers.core.github
+
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.ws.rs.client.ClientRequestContext
+import javax.ws.rs.core.HttpHeaders
+import javax.ws.rs.core.MultivaluedHashMap
+import javax.ws.rs.core.MultivaluedMap
+
+class GithubAuthenticationFilterSpec extends Specification {
+
+    public static final String TOKEN = "TOKEN"
+
+    def "Should set not empty access token"() {
+        given:
+            GithubProperties properties = new GithubProperties()
+            properties.setToken(TOKEN)
+
+            @Subject
+            GithubAuthenticationFilter testObj = new GithubAuthenticationFilter(properties)
+
+            MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>()
+
+            ClientRequestContext requestContext = Mock()
+            requestContext.getHeaders() >> headers
+
+        when:
+            testObj.filter(requestContext)
+
+        then:
+            headers.getFirst(HttpHeaders.AUTHORIZATION) == "token " + TOKEN
+    }
+
+    @Unroll
+    def "Should not set access token when access token is: #token"() {
+        given:
+            GithubProperties properties = new GithubProperties()
+            properties.setToken(token)
+
+            @Subject
+            GithubAuthenticationFilter testObj = new GithubAuthenticationFilter(properties)
+
+            MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>()
+
+            ClientRequestContext requestContext = Mock()
+            requestContext.getHeaders() >> headers
+
+        when:
+            testObj.filter(requestContext)
+
+        then:
+            headers.getFirst(HttpHeaders.AUTHORIZATION) == null
+
+        where:
+            token << [null, ""]
+//            token | _
+//            null | _
+//            "" | _
+    }
+}

--- a/src/test/groovy/com/jvm_bloggers/frontend/public_area/contributors/ContributorDetailsSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/frontend/public_area/contributors/ContributorDetailsSpec.groovy
@@ -1,0 +1,80 @@
+package com.jvm_bloggers.frontend.public_area.contributors
+
+import com.jvm_bloggers.MockSpringContextAwareSpecification
+import com.jvm_bloggers.entities.github.Contributor
+import org.apache.wicket.markup.html.link.AbstractLink
+import org.apache.wicket.model.IModel
+import org.apache.wicket.model.Model
+import spock.lang.Subject
+
+import static org.junit.Assert.assertEquals
+
+class ContributorDetailsSpec extends MockSpringContextAwareSpecification {
+
+    public static final int CONTRIBUTIONS = 666
+    public static final String LOGIN = "LOGIN"
+    public static final String AVATAR_URL = "sth.png"
+    public static final String PROFILE_URL = "https://github.com/sth"
+
+    @Override
+    protected void setupContext() {
+
+    }
+
+    def "Should have label with number of contributions"() {
+        given:
+            Contributor contributor = new Contributor()
+            contributor.setContributions(CONTRIBUTIONS)
+
+            IModel<Contributor> model = Model.of(contributor)
+
+            @Subject
+            ContributorDetails testObj = new ContributorDetails("contributorDetails", model)
+
+        when:
+            tester.startComponentInPage(testObj)
+
+        then:
+            tester.assertLabel("contributorDetails:contributions", "666")
+    }
+
+    def "Should have login linking to profile page"() {
+        given:
+            Contributor contributor = new Contributor()
+            contributor.setLogin(LOGIN)
+            contributor.setProfilePage(PROFILE_URL)
+
+            IModel<Contributor> model = Model.of(contributor)
+
+            @Subject
+            ContributorDetails testObj = new ContributorDetails("contributorDetails", model)
+
+        when:
+            tester.startComponentInPage(testObj)
+
+        then:
+            AbstractLink link = tester.getComponentFromLastRenderedPage("contributorDetails:link")
+            assertEquals(PROFILE_URL, link.getDefaultModelObject())
+            assertEquals(LOGIN, link.getBody().getObject())
+    }
+
+    def "Should have avatar linking to profile page"() {
+        given:
+            Contributor contributor = new Contributor()
+            contributor.setAvatarUrl(AVATAR_URL)
+            contributor.setLogin(LOGIN)
+            contributor.setProfilePage(PROFILE_URL)
+
+            IModel<Contributor> model = Model.of(contributor)
+
+            @Subject
+            ContributorDetails testObj = new ContributorDetails("contributorDetails", model)
+
+        when:
+            tester.startComponentInPage(testObj)
+
+        then:
+            tester.assertModelValue("contributorDetails:avatarLink", PROFILE_URL)
+            tester.assertModelValue("contributorDetails:avatarLink:avatar", AVATAR_URL)
+    }
+}

--- a/src/test/groovy/com/jvm_bloggers/frontend/public_area/contributors/ContributorsPageSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/frontend/public_area/contributors/ContributorsPageSpec.groovy
@@ -1,0 +1,30 @@
+package com.jvm_bloggers.frontend.public_area.contributors
+
+import com.jvm_bloggers.MockSpringContextAwareSpecification
+import com.jvm_bloggers.core.github.ContributorsService
+import com.jvm_bloggers.entities.github.Contributor
+import com.jvm_bloggers.frontend.public_area.newsletter_issue.NewsletterIssueDtoService
+
+class ContributorsPageSpec extends MockSpringContextAwareSpecification {
+
+    ContributorsService contributorsService = Stub(ContributorsService);
+    NewsletterIssueDtoService newsletterIssueService = Stub(NewsletterIssueDtoService)
+
+    @Override
+    protected void setupContext() {
+        addBean(contributorsService)
+        addBean(newsletterIssueService)
+    }
+
+    def "Name"() {
+        given:
+            List<Contributor> contributors = [Stub(Contributor), Stub(Contributor)]
+            contributorsService.fetchContributors() >> contributors
+
+        when:
+            tester.startPage(ContributorsPage)
+
+        then:
+            tester.assertListView("contributorsList", contributors)
+    }
+}


### PR DESCRIPTION
This is a MVP implementation. This could be further enhanced with ie. adding contributors full name instead of only login, but this would require N+1 calls to GitHub API.

Using of access token is note required, but I'd consider this a good idea in general.

One impotent thing is new config for cache invalidation `cache.spec` which affects also cache used in `AggregatedRssFeedProducer`. Personally I think that previous behavior was a bug as cache in `AggregatedRssFeedProducer` was never invalidated. 