### PR TITLE
Removing unnecessary `@Autowired` annotation from generated constructors

### DIFF
--- a/src/main/java/com/jvm_bloggers/core/InitialBlogDataPopulationTrigger.java
+++ b/src/main/java/com/jvm_bloggers/core/InitialBlogDataPopulationTrigger.java
@@ -4,9 +4,10 @@ import com.jvm_bloggers.core.data_fetching.blog_posts.BlogPostsFetchingScheduler
 import com.jvm_bloggers.core.data_fetching.blogs.BloggersDataFetchingScheduler;
 import com.jvm_bloggers.entities.blog.BlogRepository;
 import com.jvm_bloggers.entities.blog_post.BlogPostRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
@@ -20,7 +21,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Profile("!test")
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 @Slf4j
 public class InitialBlogDataPopulationTrigger {
 

--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blog_posts/BlogPostsFetchingScheduler.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blog_posts/BlogPostsFetchingScheduler.java
@@ -2,13 +2,13 @@ package com.jvm_bloggers.core.data_fetching.blog_posts;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class BlogPostsFetchingScheduler {
 
     private final BlogPostsFetcher blogPostsFetcher;

--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataFetchingScheduler.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataFetchingScheduler.java
@@ -2,13 +2,13 @@ package com.jvm_bloggers.core.data_fetching.blogs;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class BloggersDataFetchingScheduler {
 
     private final BloggersDataFetcher bloggersDataFetcher;

--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
@@ -6,14 +6,12 @@ import com.jvm_bloggers.core.rss.SyndFeedProducer;
 import com.jvm_bloggers.entities.blog.Blog;
 import com.jvm_bloggers.entities.blog.BlogRepository;
 import com.jvm_bloggers.utils.NowProvider;
-
+import javaslang.control.Option;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
-
-import javaslang.control.Option;
 
 @Component
 @Slf4j

--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
@@ -6,16 +6,18 @@ import com.jvm_bloggers.core.rss.SyndFeedProducer;
 import com.jvm_bloggers.entities.blog.Blog;
 import com.jvm_bloggers.entities.blog.BlogRepository;
 import com.jvm_bloggers.utils.NowProvider;
-import javaslang.control.Option;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import javaslang.control.Option;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class BloggersDataUpdater {
 
     private final BlogRepository blogRepository;

--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/json_data/BloggerEntry.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/json_data/BloggerEntry.java
@@ -3,11 +3,9 @@ package com.jvm_bloggers.core.data_fetching.blogs.json_data;
 import com.jvm_bloggers.entities.blog.BlogType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class BloggerEntry {
 
     private Long jsonId;

--- a/src/main/java/com/jvm_bloggers/core/data_fetching/http/ProtocolSwitchingAwareConnectionRedirectHandler.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/http/ProtocolSwitchingAwareConnectionRedirectHandler.java
@@ -1,11 +1,14 @@
 package com.jvm_bloggers.core.data_fetching.http;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import net.jcip.annotations.ThreadSafe;
+
 import org.apache.commons.collections4.MapUtils;
 
 import java.io.IOException;
@@ -27,7 +30,7 @@ import java.util.Map;
  */
 @ThreadSafe
 @Slf4j
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE, onConstructor = @__(@VisibleForTesting))
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class ProtocolSwitchingAwareConnectionRedirectHandler {
 
     @VisibleForTesting
@@ -100,8 +103,7 @@ public class ProtocolSwitchingAwareConnectionRedirectHandler {
     }
 
     private void setupHeaders(HttpURLConnection conn, Map<String, String> headers) {
-        headers.entrySet()
-            .forEach(header -> conn.setRequestProperty(header.getKey(), header.getValue()));
+        headers.forEach(conn::setRequestProperty);
     }
 
     private HttpURLConnection handleRedirect(HttpURLConnection conn) throws IOException {

--- a/src/main/java/com/jvm_bloggers/core/mailing/BlogSummaryMailGenerator.java
+++ b/src/main/java/com/jvm_bloggers/core/mailing/BlogSummaryMailGenerator.java
@@ -9,7 +9,6 @@ import com.jvm_bloggers.entities.blog_post.BlogPost;
 import com.jvm_bloggers.entities.metadata.MetadataKeys;
 import com.jvm_bloggers.entities.metadata.MetadataRepository;
 import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssue;
-import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -23,9 +22,7 @@ import static com.jvm_bloggers.core.utils.UriUtmComponentsBuilder.DEFAULT_UTM_CA
 import static com.jvm_bloggers.core.utils.UriUtmComponentsBuilder.DEFAULT_UTM_SOURCE;
 import static java.util.Collections.emptyList;
 
-
 @Component
-@NoArgsConstructor
 public class BlogSummaryMailGenerator {
 
     private static final int DAYS_IN_THE_PAST = 7;

--- a/src/main/java/com/jvm_bloggers/core/newsletter_issues/NewsletterIssueFactory.java
+++ b/src/main/java/com/jvm_bloggers/core/newsletter_issues/NewsletterIssueFactory.java
@@ -9,15 +9,16 @@ import com.jvm_bloggers.entities.metadata.MetadataKeys;
 import com.jvm_bloggers.entities.metadata.MetadataRepository;
 import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssue;
 import com.jvm_bloggers.utils.NowProvider;
+
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor
 public class NewsletterIssueFactory {
 
     private final IssueNumberRetriever issueNumberRetriever;

--- a/src/main/java/com/jvm_bloggers/core/rss/AggregatedRssFeedProducer.java
+++ b/src/main/java/com/jvm_bloggers/core/rss/AggregatedRssFeedProducer.java
@@ -16,11 +16,12 @@ import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.feed.synd.SyndFeedImpl;
 import com.rometools.rome.feed.synd.SyndLink;
 import com.rometools.rome.feed.synd.SyndLinkImpl;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
@@ -37,7 +38,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Service
 @CacheConfig(cacheNames = AggregatedRssFeedProducer.RSS_CACHE)
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 @Slf4j
 public class AggregatedRssFeedProducer {
 

--- a/src/main/java/com/jvm_bloggers/core/rss/BlogPostsController.java
+++ b/src/main/java/com/jvm_bloggers/core/rss/BlogPostsController.java
@@ -1,9 +1,10 @@
 package com.jvm_bloggers.core.rss;
 
 import com.rometools.rome.io.SyndFeedOutput;
+
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 @RestController
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class BlogPostsController {
 
     private final AggregatedRssFeedProducer rssProducer;

--- a/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueBuilder.java
+++ b/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueBuilder.java
@@ -6,10 +6,12 @@ import com.jvm_bloggers.domain.query.NewsletterIssueNumber;
 import com.jvm_bloggers.entities.blog.BlogType;
 import com.jvm_bloggers.entities.blog_post.BlogPost;
 import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssue;
-import javaslang.collection.List;
+
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.stereotype.Component;
+
+import javaslang.collection.List;
 
 import static com.jvm_bloggers.entities.blog.BlogType.COMPANY;
 import static com.jvm_bloggers.entities.blog.BlogType.PERSONAL;
@@ -17,7 +19,7 @@ import static com.jvm_bloggers.entities.blog.BlogType.VIDEOS;
 import static javaslang.collection.List.ofAll;
 
 @Component
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor
 public class PublishedNewsletterIssueBuilder {
 
     private final LinkGenerator linkGenerator;

--- a/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueBuilder.java
+++ b/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueBuilder.java
@@ -7,11 +7,11 @@ import com.jvm_bloggers.entities.blog.BlogType;
 import com.jvm_bloggers.entities.blog_post.BlogPost;
 import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssue;
 
+import javaslang.collection.List;
+
 import lombok.AllArgsConstructor;
 
 import org.springframework.stereotype.Component;
-
-import javaslang.collection.List;
 
 import static com.jvm_bloggers.entities.blog.BlogType.COMPANY;
 import static com.jvm_bloggers.entities.blog.BlogType.PERSONAL;

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/blogs/BlogsPageRequestHandler.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/blogs/BlogsPageRequestHandler.java
@@ -3,19 +3,18 @@ package com.jvm_bloggers.frontend.admin_area.blogs;
 import com.jvm_bloggers.entities.blog.Blog;
 import com.jvm_bloggers.entities.blog.BlogRepository;
 import com.jvm_bloggers.frontend.admin_area.PaginationConfiguration;
+
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.util.Iterator;
 
 @Component
-@NoArgsConstructor
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor
 public class BlogsPageRequestHandler implements IDataProvider<Blog> {
 
     private PaginationConfiguration paginationConfiguration;

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/login/attack/BruteForceAttackMailGenerator.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/login/attack/BruteForceAttackMailGenerator.java
@@ -1,9 +1,10 @@
 package com.jvm_bloggers.frontend.admin_area.login.attack;
 
 import com.jvm_bloggers.utils.NowProvider;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.stereotype.Component;
 import org.stringtemplate.v4.ST;
 
@@ -13,7 +14,7 @@ import java.time.format.DateTimeFormatter;
  * @author Adam Dec
  */
 @Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class BruteForceAttackMailGenerator {
 
     private static final String TIME = "Time";

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingAddressPageRequestHandler.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingAddressPageRequestHandler.java
@@ -3,17 +3,18 @@ package com.jvm_bloggers.frontend.admin_area.mailing;
 import com.jvm_bloggers.entities.mailing_address.MailingAddress;
 import com.jvm_bloggers.entities.mailing_address.MailingAddressRepository;
 import com.jvm_bloggers.frontend.admin_area.PaginationConfiguration;
+
 import lombok.AllArgsConstructor;
+
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.util.Iterator;
 
 @Component
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor
 public class MailingAddressPageRequestHandler implements IDataProvider<MailingAddress> {
 
     private final PaginationConfiguration paginationConfiguration;

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingPageRequestHandler.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingPageRequestHandler.java
@@ -1,6 +1,5 @@
 package com.jvm_bloggers.frontend.admin_area.mailing;
 
-
 import com.jvm_bloggers.core.mailing.EmailsWithNewIssueProducer;
 import com.jvm_bloggers.core.mailing.IssueNumberRetriever;
 import com.jvm_bloggers.core.newsletter_issues.NewsletterIssueFactory;
@@ -11,12 +10,10 @@ import com.jvm_bloggers.utils.DateTimeUtilities;
 import com.jvm_bloggers.utils.NowProvider;
 
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 
 import org.springframework.stereotype.Component;
 
 @Component
-@NoArgsConstructor
 @AllArgsConstructor
 public class MailingPageRequestHandler {
 

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingPageRequestHandler.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingPageRequestHandler.java
@@ -9,14 +9,15 @@ import com.jvm_bloggers.entities.metadata.MetadataRepository;
 import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssue;
 import com.jvm_bloggers.utils.DateTimeUtilities;
 import com.jvm_bloggers.utils.NowProvider;
+
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.stereotype.Component;
 
 @Component
 @NoArgsConstructor
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor
 public class MailingPageRequestHandler {
 
     private NowProvider nowProvider;

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/moderation/BlogPostItemPopulator.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/moderation/BlogPostItemPopulator.java
@@ -3,13 +3,14 @@ package com.jvm_bloggers.frontend.admin_area.moderation;
 import com.jvm_bloggers.entities.blog_post.BlogPost;
 import com.jvm_bloggers.frontend.admin_area.panels.CustomFeedbackPanel;
 import com.jvm_bloggers.utils.NowProvider;
+
 import lombok.RequiredArgsConstructor;
+
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.repeater.Item;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static com.jvm_bloggers.utils.DateTimeUtilities.DATE_TIME_FORMATTER;
@@ -20,7 +21,7 @@ import static org.apache.commons.lang3.StringUtils.abbreviate;
  * @author mszarlinski
  */
 @Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class BlogPostItemPopulator {
 
     private static final String ACTION_PANEL_WICKET_ID = "actionPanel";

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/moderation/ModerationPageRequestHandler.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/moderation/ModerationPageRequestHandler.java
@@ -4,11 +4,12 @@ import com.jvm_bloggers.entities.blog_post.BlogPost;
 import com.jvm_bloggers.entities.blog_post.BlogPostRepository;
 import com.jvm_bloggers.frontend.admin_area.PaginationConfiguration;
 import com.jvm_bloggers.frontend.admin_area.blogs.BlogPostModel;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +17,7 @@ import java.util.Iterator;
 
 @Component
 @Slf4j
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor
 public class ModerationPageRequestHandler implements IDataProvider<BlogPost> {
 
     private final BlogPostRepository blogPostRepository;


### PR DESCRIPTION
`@Autowired` is no longer needed on Spring constructors so removing it.

I cannot see any particular reason for `@NoArgConstructor` on `BlogsPageRequestHandler`, so removing this one as well.