### PR TITLE
Newsletter issue navigation links. Closes #319

### DIFF
--- a/src/main/java/com/jvm_bloggers/domain/query/NewsletterIssueNumber.java
+++ b/src/main/java/com/jvm_bloggers/domain/query/NewsletterIssueNumber.java
@@ -15,6 +15,14 @@ public class NewsletterIssueNumber implements Comparable<NewsletterIssueNumber> 
         return new NewsletterIssueNumber(value);
     }
 
+    public static NewsletterIssueNumber next(Long value) {
+        return new NewsletterIssueNumber(value + 1L);
+    }
+
+    public static NewsletterIssueNumber previous(Long value) {
+        return new NewsletterIssueNumber(value - 1L);
+    }
+
     public Long asLong() {
         return value;
     }

--- a/src/main/java/com/jvm_bloggers/domain/query/NewsletterIssueNumber.java
+++ b/src/main/java/com/jvm_bloggers/domain/query/NewsletterIssueNumber.java
@@ -15,12 +15,12 @@ public class NewsletterIssueNumber implements Comparable<NewsletterIssueNumber> 
         return new NewsletterIssueNumber(value);
     }
 
-    public static NewsletterIssueNumber next(Long value) {
-        return new NewsletterIssueNumber(value + 1L);
+    public static NewsletterIssueNumber next(NewsletterIssueNumber newsletterIssueNumber) {
+        return new NewsletterIssueNumber(newsletterIssueNumber.asLong() + 1L);
     }
 
-    public static NewsletterIssueNumber previous(Long value) {
-        return new NewsletterIssueNumber(value - 1L);
+    public static NewsletterIssueNumber previous(NewsletterIssueNumber newsletterIssueNumber) {
+        return new NewsletterIssueNumber(newsletterIssueNumber.asLong() - 1L);
     }
 
     public Long asLong() {

--- a/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuery.java
+++ b/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuery.java
@@ -37,21 +37,21 @@ public class PublishedNewsletterIssueQuery {
     }
 
     public Option<NewsletterIssueNumber> findNextIssueNumber(NewsletterIssueNumber issueNumber) {
-        return of(issueNumber.asLong())
+        return of(issueNumber)
             .map(NewsletterIssueNumber::next)
             .find(this::issueNumberExist);
     }
 
     public Option<NewsletterIssueNumber> findPreviousIssueNumber(
         NewsletterIssueNumber issueNumber) {
-        return of(issueNumber.asLong())
+        return of(issueNumber)
             .map(NewsletterIssueNumber::previous)
             .find(this::issueNumberExist);
     }
 
     private boolean issueNumberExist(NewsletterIssueNumber issueNumber) {
         return newsletterIssueRepository
-                .issueNumberExist(issueNumber.asLong());
+            .existsByIssueNumber(issueNumber.asLong());
     }
 
 }

--- a/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuery.java
+++ b/src/main/java/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuery.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static javaslang.collection.Stream.of;
+
 @Service
 @Transactional(readOnly = true)
 public class PublishedNewsletterIssueQuery {
@@ -32,6 +34,24 @@ public class PublishedNewsletterIssueQuery {
         return newsletterIssueRepository
                 .findByIssueNumber(issueNumber.asLong())
                 .map(publishedNewsletterIssueBuilder::build);
+    }
+
+    public Option<NewsletterIssueNumber> findNextIssueNumber(NewsletterIssueNumber issueNumber) {
+        return of(issueNumber.asLong())
+            .map(NewsletterIssueNumber::next)
+            .find(this::issueNumberExist);
+    }
+
+    public Option<NewsletterIssueNumber> findPreviousIssueNumber(
+        NewsletterIssueNumber issueNumber) {
+        return of(issueNumber.asLong())
+            .map(NewsletterIssueNumber::previous)
+            .find(this::issueNumberExist);
+    }
+
+    private boolean issueNumberExist(NewsletterIssueNumber issueNumber) {
+        return newsletterIssueRepository
+                .issueNumberExist(issueNumber.asLong());
     }
 
 }

--- a/src/main/java/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepository.java
+++ b/src/main/java/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepository.java
@@ -4,8 +4,6 @@ import javaslang.collection.List;
 import javaslang.control.Option;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,8 +18,6 @@ public interface NewsletterIssueRepository extends JpaRepository<NewsletterIssue
 
     List<NewsletterIssue> findAllByOrderByPublishedDateDesc();
 
-    @Query("select case when count(*) > 0 then true else false end "
-        + "from NewsletterIssue where issueNumber = :issueNumber")
-    boolean issueNumberExist(@Param("issueNumber") Long issueNumber);
+    boolean existsByIssueNumber(Long issueNumber);
 
 }

--- a/src/main/java/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepository.java
+++ b/src/main/java/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepository.java
@@ -4,6 +4,8 @@ import javaslang.collection.List;
 import javaslang.control.Option;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,5 +19,9 @@ public interface NewsletterIssueRepository extends JpaRepository<NewsletterIssue
     java.util.List<NewsletterIssue> findByOrderByPublishedDateDesc(Pageable request);
 
     List<NewsletterIssue> findAllByOrderByPublishedDateDesc();
+
+    @Query("select case when count(*) > 0 then true else false end "
+        + "from NewsletterIssue where issueNumber = :issueNumber")
+    boolean issueNumberExist(@Param("issueNumber") Long issueNumber);
 
 }

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/HomePage.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/HomePage.java
@@ -16,7 +16,9 @@ public class HomePage extends AbstractFrontendPage {
     public HomePage() {
         Option<PublishedNewsletterIssue> latestIssue = backingBean.getLatestIssue();
         if (latestIssue.isDefined()) {
-            add(new NewsletterIssuePanel(LATEST_ISSUE_PANEL_ID, latestIssue.get()));
+            add(new NewsletterIssuePanel(LATEST_ISSUE_PANEL_ID, latestIssue.get(),
+                backingBean.findNextIssueNumber(latestIssue.get().getNumber()),
+                backingBean.findPreviousIssueNumber(latestIssue.get().getNumber())));
         } else {
             add(new Label(LATEST_ISSUE_PANEL_ID, "Nie istnieje żadne wydanie newslettera."));
         }

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/HomePageBackingBean.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/HomePageBackingBean.java
@@ -1,5 +1,6 @@
 package com.jvm_bloggers.frontend.public_area;
 
+import com.jvm_bloggers.domain.query.NewsletterIssueNumber;
 import com.jvm_bloggers.domain.query.published_newsletter_issue.PublishedNewsletterIssue;
 import com.jvm_bloggers.domain.query.published_newsletter_issue.PublishedNewsletterIssueQuery;
 import javaslang.control.Option;
@@ -20,4 +21,12 @@ public class HomePageBackingBean {
         return publishedNewsletterIssueQuery.getLatestIssue();
     }
 
+    public Option<NewsletterIssueNumber> findNextIssueNumber(NewsletterIssueNumber issueNumber) {
+        return publishedNewsletterIssueQuery.findNextIssueNumber(issueNumber);
+    }
+
+    public Option<NewsletterIssueNumber> findPreviousIssueNumber(
+        NewsletterIssueNumber issueNumber) {
+        return publishedNewsletterIssueQuery.findPreviousIssueNumber(issueNumber);
+    }
 }

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/NewsletterIssuePage.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/NewsletterIssuePage.java
@@ -27,7 +27,9 @@ public class NewsletterIssuePage extends AbstractFrontendPage {
         Option<PublishedNewsletterIssue> foundIssue = backingBean.findByIssueNumber(issueNumber);
 
         if (foundIssue.isDefined()) {
-            add(new NewsletterIssuePanel(ISSUE_PANEL_ID, foundIssue.get()));
+            add(new NewsletterIssuePanel(ISSUE_PANEL_ID, foundIssue.get(),
+                backingBean.findNextIssueNumber(issueNumber),
+                backingBean.findPreviousIssueNumber(issueNumber)));
         } else {
             add(new Label(ISSUE_PANEL_ID, "Nie znaleziono takiego wydania"));
         }

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/NewsletterIssuePageBackingBean.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/NewsletterIssuePageBackingBean.java
@@ -21,4 +21,13 @@ public class NewsletterIssuePageBackingBean {
         return publishedNewsletterIssueQuery.findByIssueNumber(issueNumber);
     }
 
+    public Option<NewsletterIssueNumber> findNextIssueNumber(NewsletterIssueNumber issueNumber) {
+        return publishedNewsletterIssueQuery.findNextIssueNumber(issueNumber);
+    }
+
+    public Option<NewsletterIssueNumber> findPreviousIssueNumber(
+        NewsletterIssueNumber issueNumber) {
+        return publishedNewsletterIssueQuery.findPreviousIssueNumber(issueNumber);
+    }
+
 }

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/newsletter_panel/NewsletterIssueNavigationLink.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/newsletter_panel/NewsletterIssueNavigationLink.java
@@ -1,0 +1,33 @@
+package com.jvm_bloggers.frontend.public_area.newsletter_issue.newsletter_panel;
+
+import com.jvm_bloggers.domain.query.NewsletterIssueNumber;
+import com.jvm_bloggers.frontend.public_area.newsletter_issue.NewsletterIssuePage;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.model.Model;
+
+import static com.jvm_bloggers.frontend.public_area.newsletter_issue.NewsletterIssuePage.buildShowIssueParams;
+import static java.lang.String.format;
+
+public class NewsletterIssueNavigationLink extends BookmarkablePageLink<NewsletterIssuePage> {
+
+    enum Direction {
+        NEXT("Wydanie (#%d) >>"),
+        PRESIOUS("<< Wydanie (#%d)");
+
+        private String value;
+        Direction(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public NewsletterIssueNavigationLink(String id, NewsletterIssueNumber issueNumber,
+                                         Direction direction) {
+        super(id, NewsletterIssuePage.class, buildShowIssueParams(issueNumber));
+        setBody(Model.of(format(direction.getValue(), issueNumber.asLong())));
+    }
+
+}

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/newsletter_panel/NewsletterIssuePanel.html
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/newsletter_panel/NewsletterIssuePanel.html
@@ -24,6 +24,11 @@
                         <h3 wicket:enclosure="varia">Varia</h3>
                         <p wicket:id="varia"></p>
                     </p>
+                    <div class="form-group">
+                        <a wicket:id="previousNewsletterIssueNumber" href="#" class="pull-left">&lt;&lt; (Wydanie #47)</a>
+                        <a wicket:id="nextNewsletterIssueNumber" href="#" class="pull-right">(Wydanie #49) &gt;&gt;</a>
+                        <span class="clearfix"></span>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/newsletter_panel/NewsletterIssuePanel.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/newsletter_issue/newsletter_panel/NewsletterIssuePanel.java
@@ -1,6 +1,8 @@
 package com.jvm_bloggers.frontend.public_area.newsletter_issue.newsletter_panel;
 
+import com.jvm_bloggers.domain.query.NewsletterIssueNumber;
 import com.jvm_bloggers.domain.query.published_newsletter_issue.PublishedNewsletterIssue;
+import javaslang.control.Option;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 
@@ -9,7 +11,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class NewsletterIssuePanel extends Panel {
 
-    public NewsletterIssuePanel(String id, PublishedNewsletterIssue issue) {
+    public NewsletterIssuePanel(String id, PublishedNewsletterIssue issue,
+                                Option<NewsletterIssueNumber> nextIssueNumber,
+                                Option<NewsletterIssueNumber> previousIssueNumber) {
         super(id);
         add(new Label("title", "Wydanie #" + issue.getNumber().asLong()));
         add(new Label("issueDate", issue.getPublishedDate().format(DATE_FORMATTER)));
@@ -31,6 +35,8 @@ public class NewsletterIssuePanel extends Panel {
         add(new BlogPostLinksSection("linksFromVideoChannels", "Nowe nagrania", issue.getVideos()));
         add(new BlogLinksSection("newBlogs", issue.getNewBlogs()));
         addVaria(issue.getVariaSection());
+        addNextLink(nextIssueNumber);
+        addPreviousLink(previousIssueNumber);
     }
 
     private void addVaria(String variaContent) {
@@ -45,6 +51,24 @@ public class NewsletterIssuePanel extends Panel {
         heading.setEscapeModelStrings(false);
         heading.setVisible(isNotBlank(headingContent));
         add(heading);
+    }
+
+    private void addNextLink(Option<NewsletterIssueNumber> nextIssueNumber) {
+        NewsletterIssueNavigationLink next = new NewsletterIssueNavigationLink(
+            "nextNewsletterIssueNumber",
+            nextIssueNumber.getOrElse(NewsletterIssueNumber.of(-1L)),
+            NewsletterIssueNavigationLink.Direction.NEXT);
+        next.setVisible(nextIssueNumber.isDefined());
+        add(next);
+    }
+
+    private void addPreviousLink(Option<NewsletterIssueNumber> previousIssueNumber) {
+        NewsletterIssueNavigationLink previous = new NewsletterIssueNavigationLink(
+            "previousNewsletterIssueNumber",
+            previousIssueNumber.getOrElse(NewsletterIssueNumber.of(-1L)),
+            NewsletterIssueNavigationLink.Direction.PRESIOUS);
+        previous.setVisible(previousIssueNumber.isDefined());
+        add(previous);
     }
 
 }

--- a/src/test/groovy/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuerySpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuerySpec.groovy
@@ -1,0 +1,54 @@
+package com.jvm_bloggers.domain.query.published_newsletter_issue
+
+import com.jvm_bloggers.domain.query.NewsletterIssueNumber
+import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssueRepository
+import javaslang.control.Option
+import spock.lang.Specification
+import spock.lang.Subject
+
+class PublishedNewsletterIssueQuerySpec extends Specification {
+
+    NewsletterIssueRepository newsletterIssueRepository = Mock(NewsletterIssueRepository)
+    PublishedNewsletterIssueBuilder publishedNewsletterIssueBuilder = Mock(PublishedNewsletterIssueBuilder)
+
+    @Subject
+    PublishedNewsletterIssueQuery publishedNewsletterIssueQuery = new PublishedNewsletterIssueQuery(
+            newsletterIssueRepository, publishedNewsletterIssueBuilder)
+
+    def "Should find previous and next issue numbers"() {
+        given:
+        NewsletterIssueNumber issueNumber = NewsletterIssueNumber.of(22L)
+        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issueNumber.asLong())
+        NewsletterIssueNumber next = NewsletterIssueNumber.next(issueNumber.asLong())
+        newsletterIssueRepository.issueNumberExist(previous.asLong()) >> true
+        newsletterIssueRepository.issueNumberExist(next.asLong()) >> true
+
+        when:
+        Option<NewsletterIssueNumber> resultPreviousIssueNumber = publishedNewsletterIssueQuery.findPreviousIssueNumber(issueNumber)
+        Option<NewsletterIssueNumber> resultNextIssueNumber = publishedNewsletterIssueQuery.findNextIssueNumber(issueNumber)
+
+        then:
+        resultPreviousIssueNumber.isDefined()
+        resultPreviousIssueNumber.get() == previous
+        resultNextIssueNumber.isDefined()
+        resultNextIssueNumber.get() == next
+    }
+
+    def "Should not find previous and next issue numbers"() {
+        given:
+        NewsletterIssueNumber issueNumber = NewsletterIssueNumber.of(22L)
+        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issueNumber.asLong())
+        NewsletterIssueNumber next = NewsletterIssueNumber.next(issueNumber.asLong())
+        newsletterIssueRepository.issueNumberExist(previous.asLong()) >> false
+        newsletterIssueRepository.issueNumberExist(next.asLong()) >> false
+
+        when:
+        Option<NewsletterIssueNumber> resultPreviousIssueNumber = publishedNewsletterIssueQuery.findPreviousIssueNumber(issueNumber)
+        Option<NewsletterIssueNumber> resultNextIssueNumber = publishedNewsletterIssueQuery.findNextIssueNumber(issueNumber)
+
+        then:
+        !resultPreviousIssueNumber.isDefined()
+        !resultNextIssueNumber.isDefined()
+    }
+
+}

--- a/src/test/groovy/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuerySpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/domain/query/published_newsletter_issue/PublishedNewsletterIssueQuerySpec.groovy
@@ -15,40 +15,58 @@ class PublishedNewsletterIssueQuerySpec extends Specification {
     PublishedNewsletterIssueQuery publishedNewsletterIssueQuery = new PublishedNewsletterIssueQuery(
             newsletterIssueRepository, publishedNewsletterIssueBuilder)
 
-    def "Should find previous and next issue numbers"() {
+    def "Should find previous issue numbers"() {
         given:
         NewsletterIssueNumber issueNumber = NewsletterIssueNumber.of(22L)
-        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issueNumber.asLong())
-        NewsletterIssueNumber next = NewsletterIssueNumber.next(issueNumber.asLong())
-        newsletterIssueRepository.issueNumberExist(previous.asLong()) >> true
-        newsletterIssueRepository.issueNumberExist(next.asLong()) >> true
+        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issueNumber)
+        newsletterIssueRepository.existsByIssueNumber(previous.asLong()) >> true
 
         when:
         Option<NewsletterIssueNumber> resultPreviousIssueNumber = publishedNewsletterIssueQuery.findPreviousIssueNumber(issueNumber)
-        Option<NewsletterIssueNumber> resultNextIssueNumber = publishedNewsletterIssueQuery.findNextIssueNumber(issueNumber)
 
         then:
         resultPreviousIssueNumber.isDefined()
         resultPreviousIssueNumber.get() == previous
+    }
+
+    def "Should find next issue numbers"() {
+        given:
+        NewsletterIssueNumber issueNumber = NewsletterIssueNumber.of(22L)
+        NewsletterIssueNumber next = NewsletterIssueNumber.next(issueNumber)
+        newsletterIssueRepository.existsByIssueNumber(next.asLong()) >> true
+
+        when:
+        Option<NewsletterIssueNumber> resultNextIssueNumber = publishedNewsletterIssueQuery.findNextIssueNumber(issueNumber)
+
+        then:
         resultNextIssueNumber.isDefined()
         resultNextIssueNumber.get() == next
     }
 
-    def "Should not find previous and next issue numbers"() {
+    def "Should not find previous issue numbers"() {
         given:
         NewsletterIssueNumber issueNumber = NewsletterIssueNumber.of(22L)
-        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issueNumber.asLong())
-        NewsletterIssueNumber next = NewsletterIssueNumber.next(issueNumber.asLong())
-        newsletterIssueRepository.issueNumberExist(previous.asLong()) >> false
-        newsletterIssueRepository.issueNumberExist(next.asLong()) >> false
+        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issueNumber)
+        newsletterIssueRepository.existsByIssueNumber(previous.asLong()) >> false
 
         when:
         Option<NewsletterIssueNumber> resultPreviousIssueNumber = publishedNewsletterIssueQuery.findPreviousIssueNumber(issueNumber)
+
+        then:
+        resultPreviousIssueNumber.isEmpty()
+    }
+
+    def "Should not find next issue numbers"() {
+        given:
+        NewsletterIssueNumber issueNumber = NewsletterIssueNumber.of(22L)
+        NewsletterIssueNumber next = NewsletterIssueNumber.next(issueNumber)
+        newsletterIssueRepository.existsByIssueNumber(next.asLong()) >> false
+
+        when:
         Option<NewsletterIssueNumber> resultNextIssueNumber = publishedNewsletterIssueQuery.findNextIssueNumber(issueNumber)
 
         then:
-        !resultPreviousIssueNumber.isDefined()
-        !resultNextIssueNumber.isDefined()
+        resultNextIssueNumber.isEmpty()
     }
 
 }

--- a/src/test/groovy/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepositorySpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepositorySpec.groovy
@@ -1,0 +1,30 @@
+package com.jvm_bloggers.entities.newsletter_issue
+
+import com.jvm_bloggers.entities.blog.Blog
+import com.jvm_bloggers.entities.blog_post.BlogPost
+
+class NewsletterIssueRepositorySpec extends NewsletterIssueRepositorySpecBase {
+
+    def "Should check existence of issue base on issueNumber"() {
+        given:
+        Long issueNumber = 1L
+        List<Blog> blogs = prepareBlogs()
+        List<BlogPost> posts = prepareBlogPosts(blogs.get(0), blogs.get(1))
+        NewsletterIssue issue = buildNewsletterIssue(issueNumber, blogs, posts, 'heading', 'varia')
+
+        and:
+        newsletterIssueRepository.save(issue)
+
+        when:
+        boolean newsletterIssueExist = newsletterIssueRepository.issueNumberExist(testIssueNumber)
+
+        then:
+        newsletterIssueExist == expectedResult
+
+        where:
+        testIssueNumber || expectedResult
+        1L              || true
+        2L              || false
+    }
+
+}

--- a/src/test/groovy/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepositorySpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepositorySpec.groovy
@@ -16,7 +16,7 @@ class NewsletterIssueRepositorySpec extends NewsletterIssueRepositorySpecBase {
         newsletterIssueRepository.save(issue)
 
         when:
-        boolean newsletterIssueExist = newsletterIssueRepository.issueNumberExist(testIssueNumber)
+        boolean newsletterIssueExist = newsletterIssueRepository.existsByIssueNumber(testIssueNumber)
 
         then:
         newsletterIssueExist == expectedResult

--- a/src/test/groovy/com/jvm_bloggers/frontend/public_area/newsletter_issue/NewsletterIssuePageSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/frontend/public_area/newsletter_issue/NewsletterIssuePageSpec.groovy
@@ -70,17 +70,16 @@ class NewsletterIssuePageSpec extends MockSpringContextAwareSpecification {
         tester.assertContains("Nie znaleziono takiego wydania")
     }
 
-    def "Should display previous and next navigation links"() {
+    def "Should display previous navigation link"() {
         given:
         PublishedNewsletterIssue issue = prepareExampleIssue()
-        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issue.number.asLong())
-        NewsletterIssueNumber next = NewsletterIssueNumber.next(issue.number.asLong())
+        NewsletterIssueNumber previous = NewsletterIssueNumber.previous(issue.number)
 
         @Subject
         NewsletterIssuePanel newsletterIssuePanel = new NewsletterIssuePanel(
                 ISSUE_PANEL_ID,
                 issue,
-                Option.of(next),
+                Option.none(),
                 Option.of(previous))
 
         when:
@@ -90,12 +89,30 @@ class NewsletterIssuePageSpec extends MockSpringContextAwareSpecification {
         tester.assertComponent("$ISSUE_PANEL_ID:previousNewsletterIssueNumber", NewsletterIssueNavigationLink)
         tester.assertBookmarkablePageLink("$ISSUE_PANEL_ID:previousNewsletterIssueNumber", NewsletterIssuePage, buildShowIssueParams(previous))
         tester.getTagByWicketId('previousNewsletterIssueNumber').value == HtmlUtils.htmlEscape(format(NewsletterIssueNavigationLink.Direction.PRESIOUS.value, previous.asLong()))
+    }
+
+    def "Should display next navigation link"() {
+        given:
+        PublishedNewsletterIssue issue = prepareExampleIssue()
+        NewsletterIssueNumber next = NewsletterIssueNumber.next(issue.number)
+
+        @Subject
+        NewsletterIssuePanel newsletterIssuePanel = new NewsletterIssuePanel(
+                ISSUE_PANEL_ID,
+                issue,
+                Option.of(next),
+                Option.none())
+
+        when:
+        tester.startComponentInPage(newsletterIssuePanel)
+
+        then:
         tester.assertComponent("$ISSUE_PANEL_ID:nextNewsletterIssueNumber", NewsletterIssueNavigationLink)
         tester.assertBookmarkablePageLink("$ISSUE_PANEL_ID:nextNewsletterIssueNumber", NewsletterIssuePage, buildShowIssueParams(next))
         tester.getTagByWicketId('nextNewsletterIssueNumber').value == HtmlUtils.htmlEscape(format(NewsletterIssueNavigationLink.Direction.NEXT.value, next.asLong()))
     }
 
-    def "Should not display previous and next navigation links"() {
+    def "Should not display previous navigation link"() {
         given:
         PublishedNewsletterIssue issue = prepareExampleIssue()
 
@@ -111,6 +128,23 @@ class NewsletterIssuePageSpec extends MockSpringContextAwareSpecification {
 
         then:
         tester.getTagByWicketId('previousNewsletterIssueNumber') == null
+    }
+
+    def "Should not display next navigation links"() {
+        given:
+        PublishedNewsletterIssue issue = prepareExampleIssue()
+
+        @Subject
+        NewsletterIssuePanel newsletterIssuePanel = new NewsletterIssuePanel(
+                ISSUE_PANEL_ID,
+                issue,
+                Option.none(),
+                Option.none())
+
+        when:
+        tester.startComponentInPage(newsletterIssuePanel)
+
+        then:
         tester.getTagByWicketId('nextNewsletterIssueNumber') == null
     }
 


### PR DESCRIPTION
PR which adds previous and next links at the bottom of `NewsletterIssuePanel`