### PR TITLE
Make xml format as a default in RSS, fixes #395

### DIFF
--- a/src/main/java/com/jvm_bloggers/core/rss/BlogPostsController.java
+++ b/src/main/java/com/jvm_bloggers/core/rss/BlogPostsController.java
@@ -38,7 +38,7 @@ public class BlogPostsController {
     @RequestMapping(
         method = RequestMethod.GET,
         path = RSS_FEED_MAPPING,
-        produces = {APPLICATION_JSON_UTF8_VALUE, APPLICATION_ATOM_XML_VALUE}
+        produces = {APPLICATION_ATOM_XML_VALUE, APPLICATION_JSON_UTF8_VALUE}
     )
     public SyndFeed getRss(HttpServletRequest request,
                            @RequestParam(required = false) Integer limit,

--- a/src/test/groovy/com/jvm_bloggers/core/rss/BlogPostsControllerSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/rss/BlogPostsControllerSpec.groovy
@@ -15,6 +15,8 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 
 class BlogPostsControllerSpec extends SpringContextAwareSpecification {
 
+    private static final String BROWSER_ACCEPT_HEADER = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0"
+
     @Autowired
     WebApplicationContext webApplicationContext
 
@@ -25,7 +27,8 @@ class BlogPostsControllerSpec extends SpringContextAwareSpecification {
                 .build()
 
         expect:
-        mockMvc.perform(get("/pl/rss.$format"))
+        mockMvc.perform(get("/pl/rss.$format")
+                .header("Accept", BROWSER_ACCEPT_HEADER))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(mediaType))
 
@@ -35,4 +38,5 @@ class BlogPostsControllerSpec extends SpringContextAwareSpecification {
         "xml"  || APPLICATION_ATOM_XML_VALUE
         ""     || APPLICATION_ATOM_XML_VALUE
     }
+
 }


### PR DESCRIPTION
Adds xml as a first produced media type in BlogPostsController.java, makes test more specific by using real "Accept" header from browser, fixes #395 