### PR TITLE
Force build to run on isolated GCE VM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+sudo: required
+
 jdk:
     - oraclejdk8
 


### PR DESCRIPTION
I noticed that some builds that work on local machine are failing on CI with following message:

`Process 'Gradle Test Executor 2' finished with non-zero exit value 137`

which can indicate that build is using too many resources. 

This issue can be related to [recent change](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default) in travis where default distribution is now `trusty`. One of the suggestion to fix this was to use [sudo: required](https://docs.travis-ci.com/user/reference/trusty#Fully-virtualized-via-sudo%3A-required) command.