### PR TITLE
Infinite scroll respect last page.

### DIFF
--- a/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/InfinitePaginationPanel.html
+++ b/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/InfinitePaginationPanel.html
@@ -5,8 +5,11 @@
 <wicket:panel>
 
     <div class="clearfix"></div>
-    <ul id="pager" wicket:id="pager" class="hidden-navigation"></ul>
-    <a wicket:id="next-page"></a>
+    <div class="hidden-navigation">
+        <ul id="pager" wicket:id="pager"></ul>
+        <a wicket:id="next-page"></a>
+        <span wicket:id="total-page-count"></span>
+    </div>
 
 </wicket:panel>
 

--- a/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/InfinitePaginationPanel.java
+++ b/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/InfinitePaginationPanel.java
@@ -23,16 +23,23 @@ public class InfinitePaginationPanel extends Panel {
 
         callbackUrl = new Model<>();
         pager = new AjaxPagingNavigator("pager", dataView);
+        long totalPageCountValue = pager.getPageable().getPageCount();
         Component nextLink = new Label("next-page").add(new AttributeModifier("href", callbackUrl));
+        Component totalPageCount = new Label("total-page-count", totalPageCountValue);
 
         add(pager);
         add(nextLink);
-        add(newInfiniteScrollingBehavior(nextLink));
+        add(totalPageCount);
+        if (totalPageCountValue > 1) {
+            add(newInfiniteScrollingBehavior(nextLink, totalPageCount));
+        }
     }
 
-    protected InfiniteScrollingBehavior newInfiniteScrollingBehavior(final Component nextLink) {
+    protected InfiniteScrollingBehavior newInfiniteScrollingBehavior(final Component nextLink,
+                                                           final Component totalPageCount) {
         final InfiniteScrollingBehavior scrollingBehavior = new InfiniteScrollingBehavior();
         scrollingBehavior.setNextSelector(nextLink);
+        scrollingBehavior.setTotalPageCountSelector(totalPageCount);
 
         return scrollingBehavior;
     }

--- a/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/InfiniteScrollingBehavior.java
+++ b/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/InfiniteScrollingBehavior.java
@@ -54,6 +54,7 @@ public class InfiniteScrollingBehavior extends Behavior {
 
     private CharSequence createScript(Component component) {
         return format(""
+            + "var $infiniteScrollTotalPageCount = parseInt(jQuery('%s').text());"
             + "var $infiniteScrollContainer = jQuery('#%s').infiniteScroll({\n"
             + "  path: function() {\n"
             + "    return document.querySelector('%s')\n"
@@ -62,7 +63,8 @@ public class InfiniteScrollingBehavior extends Behavior {
             + "  append: '.item',\n"
             + "  responseType: 'text',\n"
             + "  debug: %s\n"
-            + "});", component.getMarkupId(), jsonData.get("nextSelector"), jsonData.get("debug"));
+            + "});", jsonData.get("totalPageSelector"), component.getMarkupId(),
+            jsonData.get("nextSelector"), jsonData.get("debug"));
     }
 
     @Override
@@ -74,6 +76,12 @@ public class InfiniteScrollingBehavior extends Behavior {
     public InfiniteScrollingBehavior setNextSelector(Component component) {
         component.setOutputMarkupId(true);
         jsonData.put("nextSelector", "#" + component.getMarkupId(true));
+        return this;
+    }
+
+    public InfiniteScrollingBehavior setTotalPageCountSelector(Component component) {
+        component.setOutputMarkupId(true);
+        jsonData.put("totalPageSelector", "#" + component.getMarkupId(true));
         return this;
     }
 

--- a/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/js/infinite-scroll-event-listener.js
+++ b/src/main/java/com/jvm_bloggers/frontend/common_components/infinite_scroll/js/infinite-scroll-event-listener.js
@@ -1,10 +1,17 @@
 $infiniteScrollContainer.on( 'load.infiniteScroll', function( event, response ) {
+    var infScroll = $infiniteScrollContainer.data('infiniteScroll');
     var items = $(response).find("component")[0];
     if (items === undefined || response.indexOf('AccessDeniedPage') > -1) {
-        $infiniteScrollContainer.data('infiniteScroll').canLoad = false;
+        infScroll.canLoad = false;
     }
 
     var $items = $(items).find('.item');
     $infiniteScrollContainer.infiniteScroll( 'appendItems', $items );
-    $infiniteScrollContainer.data('infiniteScroll').isLoading = false;
+    infScroll.isLoading = false;
+
+    if (infScroll.loadCount == $infiniteScrollTotalPageCount - 1) {
+        $infiniteScrollContainer.infiniteScroll( 'option', {
+            loadOnScroll: false
+        });
+    }
 });

--- a/src/test/groovy/com/jvm_bloggers/frontend/common_components/InfinitePaginationPanelSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/frontend/common_components/InfinitePaginationPanelSpec.groovy
@@ -32,7 +32,7 @@ class InfinitePaginationPanelSpec extends MockSpringContextAwareSpecification {
         tester.startComponentInPage(infinitePaginationPanel)
 
         then:
-        0 == tester.getComponentFromLastRenderedPage(panelId).getBehaviors(InfiniteScrollingBehavior).size()
+        tester.getComponentFromLastRenderedPage(panelId).getBehaviors(InfiniteScrollingBehavior).isEmpty()
     }
 
     @Override

--- a/src/test/groovy/com/jvm_bloggers/frontend/common_components/InfinitePaginationPanelSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/frontend/common_components/InfinitePaginationPanelSpec.groovy
@@ -1,0 +1,42 @@
+package com.jvm_bloggers.frontend.common_components
+
+import com.jvm_bloggers.MockSpringContextAwareSpecification
+import com.jvm_bloggers.frontend.common_components.infinite_scroll.InfinitePaginationPanel
+import com.jvm_bloggers.frontend.common_components.infinite_scroll.InfiniteScrollingBehavior
+import org.apache.wicket.markup.repeater.data.DataView
+
+class InfinitePaginationPanelSpec extends MockSpringContextAwareSpecification {
+
+    def "Should add InfiniteScrollingBehavior to component when pageCount > 1"() {
+        given:
+        String panelId = "someId"
+        DataView dataView = Stub(DataView)
+        dataView.getPageCount() >> 2
+        InfinitePaginationPanel infinitePaginationPanel = new InfinitePaginationPanel(panelId, dataView)
+
+        when:
+        tester.startComponentInPage(infinitePaginationPanel)
+
+        then:
+        1 == tester.getComponentFromLastRenderedPage(panelId).getBehaviors(InfiniteScrollingBehavior).size()
+    }
+
+    def "Should don't add InfiniteScrollingBehavior to component when pageCount <= 1"() {
+        given:
+        String panelId = "someId"
+        DataView dataView = Stub(DataView)
+        dataView.getPageCount() >> 1
+        InfinitePaginationPanel infinitePaginationPanel = new InfinitePaginationPanel(panelId, dataView)
+
+        when:
+        tester.startComponentInPage(infinitePaginationPanel)
+
+        then:
+        0 == tester.getComponentFromLastRenderedPage(panelId).getBehaviors(InfiniteScrollingBehavior).size()
+    }
+
+    @Override
+    protected void setupContext() {
+
+    }
+}


### PR DESCRIPTION
Today infinity scroll stops loading more data when an error is returned for requesting lastPage + 1, this is ok but this print WARN message to the logs. This PR introduces handling this scenario in following way:
1) When number of pages > 1 then disable infinite scroll when on second to the last page
2) When number of pages <= 1 then do not add infinity scroll behaviour