### PR TITLE
Updated Sii feed URL

### DIFF
--- a/src/main/resources/blogs/companies.json
+++ b/src/main/resources/blogs/companies.json
@@ -57,7 +57,7 @@
     {
       "bookmarkableId": "sii",
       "name": "Sii",
-      "rss": "http://blogersii.pl/feed/",
+      "rss": "https://sii.pl/blog/feed/",
       "twitter": "@Sii_Polska"
     },
     {


### PR DESCRIPTION
Sii's blog URL has changed. Feed in previous URL is redirecting correctly, but one of article from the blog didn't showed up on jvm-bloggers issue.
Hope this modification will fix it.
Thx