### PR TITLE
Add Dawid Pura's blog; remove trailing space from kodujze rss entry

### DIFF
--- a/src/main/resources/blogs/bloggers.json
+++ b/src/main/resources/blogs/bloggers.json
@@ -1124,7 +1124,12 @@
     {
       "bookmarkableId": "kodujze",
       "name": "Maciej Marczak",
-      "rss": "https://www.kodujze.pl/feed/" 
+      "rss": "https://www.kodujze.pl/feed/"
+    },
+    {
+      "bookmarkableId": "puradawid",
+      "name": "Dawid Pura",
+      "rss": "https://puradawid.pro/feed.xml"
     }
   ]
 }


### PR DESCRIPTION
Adding my own blog feed, but also noticed there is a trailing space before my entry, hence it's removed.