### PR TITLE
Fixed Espeo blog to show only dev topics

### DIFF
--- a/src/main/resources/blogs/companies.json
+++ b/src/main/resources/blogs/companies.json
@@ -63,7 +63,7 @@
     {
       "bookmarkableId": "espeo",
       "name": "Espeo",
-      "rss": "http://espeo.eu/blog/category/all/feed/",
+      "rss": "https://espeo.eu/blog/category/technology/feed/",
       "twitter": "@espeo_software"
     },
     {


### PR DESCRIPTION
Previous link pointed to `all` blog posts, sometimes not related to programming