### PR TITLE
Update Lombok version and remove old-style constructor autowiring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     compile 'de.agilecoders.wicket.webjars:wicket-webjars:2.0.3'
 
     // Utils and helpers
-    compile 'org.projectlombok:lombok:1.16.18'
+    compile 'org.projectlombok:lombok:1.18.8'
     compile 'com.google.guava:guava:23.5-jre'
     compile 'org.apache.commons:commons-lang3:3.7'
     compile 'org.apache.commons:commons-text:1.1'

--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/json_data/BloggerEntry.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/json_data/BloggerEntry.java
@@ -3,9 +3,11 @@ package com.jvm_bloggers.core.data_fetching.blogs.json_data;
 import com.jvm_bloggers.entities.blog.BlogType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class BloggerEntry {
 
     private String bookmarkableId;

--- a/src/main/java/com/jvm_bloggers/core/newsletter_issues/NewsletterIssueFactory.java
+++ b/src/main/java/com/jvm_bloggers/core/newsletter_issues/NewsletterIssueFactory.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor(onConstructor_ = {@Autowired})
 @NoArgsConstructor
 public class NewsletterIssueFactory {
 

--- a/src/main/java/com/jvm_bloggers/core/social/twitter/publisher/Twitter4jPublisher.java
+++ b/src/main/java/com/jvm_bloggers/core/social/twitter/publisher/Twitter4jPublisher.java
@@ -25,7 +25,7 @@ class Twitter4jPublisher implements TwitterPublisher {
 
     @Override
     public TwitterPublishingStatus publish(Tweet tweet) {
-        return Try.of(() -> clientFactory.getClient())
+        return Try.of(clientFactory::getClient)
             .mapTry(twitter -> twitter.updateStatus(tweet.getContent()))
             .onSuccess(status -> log.info("Tweet published successfully {}", status))
             .map(status -> SUCCESS)

--- a/src/main/java/com/jvm_bloggers/domain/query/blog_statistics_for_listing/BlogStatisticsForListingQuery.java
+++ b/src/main/java/com/jvm_bloggers/domain/query/blog_statistics_for_listing/BlogStatisticsForListingQuery.java
@@ -5,7 +5,6 @@ import com.jvm_bloggers.entities.blog.BlogType;
 import com.jvm_bloggers.utils.NowProvider;
 import io.vavr.collection.List;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -13,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor
 public class BlogStatisticsForListingQuery {
 
     public static final String BLOG_STATISTICS_CACHE = "Blog posts statistics cache";

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingPageBackingBean.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/mailing/MailingPageBackingBean.java
@@ -14,17 +14,15 @@ import com.jvm_bloggers.entities.metadata.MetadataKeys;
 import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssue;
 import com.jvm_bloggers.utils.DateTimeUtilities;
 import com.jvm_bloggers.utils.NowProvider;
-
 import io.vavr.collection.List;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 @NoArgsConstructor
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor(onConstructor_ = {@Autowired})
 public class MailingPageBackingBean {
 
     private CommandPublisher commandPublisher;

--- a/src/main/java/com/jvm_bloggers/frontend/admin_area/moderation/ModerationPageRequestHandler.java
+++ b/src/main/java/com/jvm_bloggers/frontend/admin_area/moderation/ModerationPageRequestHandler.java
@@ -4,11 +4,9 @@ import com.jvm_bloggers.entities.blog_post.BlogPost;
 import com.jvm_bloggers.entities.blog_post.BlogPostRepository;
 import com.jvm_bloggers.frontend.admin_area.PaginationConfiguration;
 import com.jvm_bloggers.frontend.admin_area.blogs.BlogPostModel;
-
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +18,7 @@ import java.util.Iterator;
 @Component
 @Slf4j
 @NoArgsConstructor
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor(onConstructor_ = {@Autowired})
 public class ModerationPageRequestHandler implements IDataProvider<BlogPost> {
 
     private BlogPostRepository blogPostRepository;

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/blogs/AbstractBlogsPageBackingBean.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/blogs/AbstractBlogsPageBackingBean.java
@@ -3,15 +3,12 @@ package com.jvm_bloggers.frontend.public_area.blogs;
 import com.jvm_bloggers.domain.query.blog_statistics_for_listing.BlogStatisticsForListing;
 import com.jvm_bloggers.entities.blog.BlogType;
 import com.jvm_bloggers.frontend.admin_area.PaginationConfiguration;
-
 import lombok.RequiredArgsConstructor;
-
 import org.apache.wicket.markup.repeater.Item;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 public class AbstractBlogsPageBackingBean {
 
     private final BlogWithStatisticsItemPopulator blogWithStatisticsItemPopulator;

--- a/src/main/java/com/jvm_bloggers/frontend/public_area/varia_suggestion/VariaSuggestionPageBackingBean.java
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/varia_suggestion/VariaSuggestionPageBackingBean.java
@@ -2,16 +2,14 @@ package com.jvm_bloggers.frontend.public_area.varia_suggestion;
 
 import com.jvm_bloggers.domain.command.CommandPublisher;
 import com.jvm_bloggers.domain.command.new_varia_suggestion.CreateNewVariaSuggestion;
-
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 @NoArgsConstructor
-@AllArgsConstructor(onConstructor = @__(@Autowired))
+@AllArgsConstructor(onConstructor_ = {@Autowired})
 public class VariaSuggestionPageBackingBean {
 
     private CommandPublisher commandPublisher;

--- a/src/test/groovy/com/jvm_bloggers/core/utils/LocalDateToTimestampConverterSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/utils/LocalDateToTimestampConverterSpec.groovy
@@ -1,6 +1,5 @@
 package com.jvm_bloggers.core.utils
 
-import com.jvm_bloggers.utils.NowProvider
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -8,6 +7,8 @@ import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+
+import static java.time.ZoneId.systemDefault
 
 @Subject(LocalDateToTimestampConverter)
 class LocalDateToTimestampConverterSpec extends Specification {
@@ -28,8 +29,8 @@ class LocalDateToTimestampConverterSpec extends Specification {
         localDate.getYear() == localDateTime.getYear()
     }
 
-    private Timestamp convertToTimestamp(LocalDateTime localDateTime) {
-        Instant instant = localDateTime.atZone(NowProvider.DEFAULT_ZONE).toInstant()
+    private static Timestamp convertToTimestamp(LocalDateTime localDateTime) {
+        Instant instant = localDateTime.atZone(systemDefault()).toInstant()
         Timestamp timestamp = Timestamp.from(instant)
         return timestamp
     }

--- a/src/test/groovy/com/jvm_bloggers/frontend/admin_area/login/attack/BruteForceAttackMailGeneratorSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/frontend/admin_area/login/attack/BruteForceAttackMailGeneratorSpec.groovy
@@ -12,7 +12,7 @@ import java.time.Month
 class BruteForceAttackMailGeneratorSpec extends Specification {
 
     NowProvider nowProvider;
-    BruteForceAttackMailGenerator bruteForceAttackMailGenerator;
+    BruteForceAttackMailGenerator bruteForceAttackMailGenerator
 
     def setup() {
         nowProvider = Mock(NowProvider)
@@ -22,47 +22,47 @@ class BruteForceAttackMailGeneratorSpec extends Specification {
 
     def "Should not prepare mail content due to null BruteForceAttackEvent"() {
         given:
-        BruteForceAttackEvent event = null;
+        BruteForceAttackEvent event = null
 
         when:
         bruteForceAttackMailGenerator.prepareMailContent(event)
 
         then:
         NullPointerException ex = thrown()
-        ex.message.equals("bruteForceAttackEvent")
+        ex.message == "bruteForceAttackEvent is marked non-null but is null"
     }
 
     def "Should prepare mail content with null IP address"() {
         given:
-        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress(null).build();
+        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress(null).build()
 
         when:
         String content = bruteForceAttackMailGenerator.prepareMailContent(event)
 
         then:
-        content.equals("Brute Force attack detected from IP:  at 12:00:00")
+        content == "Brute Force attack detected from IP:  at 12:00:00"
     }
 
     def "Should prepare mail content with blank IP address"() {
         given:
-        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("").build();
+        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("").build()
 
         when:
         String content = bruteForceAttackMailGenerator.prepareMailContent(event)
 
         then:
-        content.equals("Brute Force attack detected from IP:  at 12:00:00")
+        content == "Brute Force attack detected from IP:  at 12:00:00"
     }
 
     def "Should prepare mail content"() {
         given:
-        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("127.0.0.1").build();
+        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("127.0.0.1").build()
 
         when:
         String content = bruteForceAttackMailGenerator.prepareMailContent(event)
 
         then:
-        content.equals("Brute Force attack detected from IP: 127.0.0.1 at 12:00:00")
+        content == "Brute Force attack detected from IP: 127.0.0.1 at 12:00:00"
     }
 
     def "Should not prepare mail title due to null BruteForceAttackEvent"() {
@@ -74,39 +74,39 @@ class BruteForceAttackMailGeneratorSpec extends Specification {
 
         then:
         NullPointerException ex = thrown()
-        ex.message.equals("bruteForceAttackEvent")
+        ex.message == "bruteForceAttackEvent is marked non-null but is null"
     }
 
     def "Should prepare mail title with null IP address"() {
         given:
-        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress(null).build();
+        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress(null).build()
 
         when:
         String content = bruteForceAttackMailGenerator.prepareMailTitle(event)
 
         then:
-        content.equals("Brute force attack detected for ")
+        content == "Brute force attack detected for "
     }
 
     def "Should prepare mail title with blank IP address"() {
         given:
-        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("").build();
+        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("").build()
 
         when:
         String content = bruteForceAttackMailGenerator.prepareMailTitle(event)
 
         then:
-        content.equals("Brute force attack detected for ")
+        content == "Brute force attack detected for "
     }
 
     def "Should prepare mail title"() {
         given:
-        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("127.0.0.1").build();
+        BruteForceAttackEvent event = new BruteForceAttackEvent.BruteForceAttackEventBuilder().ipAddress("127.0.0.1").build()
 
         when:
         String content = bruteForceAttackMailGenerator.prepareMailTitle(event)
 
         then:
-        content.equals("Brute force attack detected for 127.0.0.1")
+        content == "Brute force attack detected for 127.0.0.1"
     }
 }


### PR DESCRIPTION
Changes: 

- update Lombok to 1.18.8
- add changes required for compatibility with new version of Lombok
- change old-style constructor autowiring
- remove @Autowire if not required
- update test that fails in other timezone