### PR TITLE
Tornimo.io news & blog

### DIFF
--- a/src/main/resources/blogs/companies.json
+++ b/src/main/resources/blogs/companies.json
@@ -151,7 +151,7 @@
       "twitter": "@AzimoLabs"
     },
     {
-      "bookmarkableId": "tornimo.io",
+      "bookmarkableId": "tornimo",
       "name": "Tornimo.io",
       "rss": "http://tornimo.io/news/feed/",
       "twitter": "@tornimoio"

--- a/src/main/resources/blogs/companies.json
+++ b/src/main/resources/blogs/companies.json
@@ -149,6 +149,12 @@
       "name": "Azimo Labs",
       "rss": "https://medium.com/feed/azimolabs",
       "twitter": "@AzimoLabs"
+    },
+    {
+      "bookmarkableId": "tornimo.io",
+      "name": "Tornimo.io",
+      "rss": "http://tornimo.io/news/feed/",
+      "twitter": "@tornimoio"
     }
   ]
 }


### PR DESCRIPTION
Kindly please add Tornimo blog to JVM Bloggers. We used to publish small product updates there and recently started posting longer articles. So far about [CDN](https://tornimo.io/blog/are-you-using-your-cdn-wrong-get-more-out-of-your-provider/) and [UX](https://tornimo.io/blog/its-not-always-about-bad-design-performance-in-user-experience/). In time Java content should also appear there.

Thanks!