### PR TITLE
Remove unused twitter template message

### DIFF
--- a/src/main/java/com/jvm_bloggers/core/social/twitter/TweetContentGenerator.java
+++ b/src/main/java/com/jvm_bloggers/core/social/twitter/TweetContentGenerator.java
@@ -22,15 +22,11 @@ import static lombok.AccessLevel.PACKAGE;
 @RequiredArgsConstructor(access = PACKAGE)
 class TweetContentGenerator {
 
-    private static final int TWEET_MAX_LENGTH = 250;
     private static final String MESSAGE_TEMPLATE =
         "Nowy numer #<number> już online - <link> z postami między innymi <personal1>"
             + "<if(company && personal2)>, <company> i <personal2>"
             + "<elseif(company)> i <company>"
             + "<elseif(personal2)> i <personal2><endif> #java #jvm";
-    private static final String SHORT_MESSAGE_TEMPLATE =
-        "Nowy numer #<number> już online - <link> z postami między innymi <personal>"
-            + "<if(company)> i <company><endif> #java #jvm";
 
     private final LinkGenerator linkGenerator;
 
@@ -63,22 +59,6 @@ class TweetContentGenerator {
         template.add("personal1", personals.head());
         template.add("personal2", personals.last());
         template.add("company", company);
-        final String tweetContent = template.render();
-
-        if (tweetIsTooLong(tweetContent, issueLink.length())) {
-            final ST shortTemplate = new ST(SHORT_MESSAGE_TEMPLATE);
-            shortTemplate.add("number", issue.getIssueNumber());
-            shortTemplate.add("link", issueLink);
-            shortTemplate.add("personal", personals.head());
-            shortTemplate.add("company", company);
-            return shortTemplate.render();
-        } else {
-            return tweetContent;
-        }
+        return template.render();
     }
-
-    private boolean tweetIsTooLong(String tweetContent, int originalIssuesLinkLength) {
-        return (tweetContent.length() - originalIssuesLinkLength + 23) > TWEET_MAX_LENGTH;
-    }
-
 }

--- a/src/test/groovy/com/jvm_bloggers/core/data_fetching/blogs/json_data/JsonBlogsDataFileValidationSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/data_fetching/blogs/json_data/JsonBlogsDataFileValidationSpec.groovy
@@ -13,7 +13,7 @@ class JsonBlogsDataFileValidationSpec extends Specification {
     @Shared
     List<BloggerEntry> jsonEntries
 
-    private static final int TWITTER_USER_TAG_MAXIMUM_LENGTH = 16
+    private static final int AT_PLUS_TWITTER_HANDLE_MAX_LENGTH = 16
 
     private static final CharMatcher alphanumericOrUnderscore = (CharMatcher.inRange('a' as char, 'z' as char) as CharMatcher)
             .or(CharMatcher.inRange('A' as char, 'Z' as char) as CharMatcher)
@@ -39,7 +39,7 @@ class JsonBlogsDataFileValidationSpec extends Specification {
     }
 
     @Unroll
-    def "should check that bookmarkable ID is lower-case, alphanumeric or hyphen"() {
+    def "should check that bookmarkable ID  #id is lower-case, alphanumeric or hyphen"() {
         expect:
         lowercaseOrHyphen.matchesAllOf(id)
 
@@ -66,35 +66,35 @@ class JsonBlogsDataFileValidationSpec extends Specification {
     }
 
     @Unroll
-    def "should check that twitter user tag starts with @"() {
+    def "should check that @ + twitter handle #atPlusTwitterHandle starts with @"() {
         expect:
-        tag.startsWith("@")
+        atPlusTwitterHandle.startsWith("@")
 
         where:
-        tag << allTwitterUsersTags()
+        atPlusTwitterHandle << allAtPlusTwitterUserNames()
     }
 
 
     @Unroll
-    def "should check that twitter user tag is less than 16 characters"() {
+    def "should check that @ + twitter handle #atPlusTwitterHandle is less than 16 characters"() {
         expect:
-        tag.length() <= TWITTER_USER_TAG_MAXIMUM_LENGTH
+        atPlusTwitterHandle.length() <= AT_PLUS_TWITTER_HANDLE_MAX_LENGTH
 
         where:
-        tag << allTwitterUsersTags()
+        atPlusTwitterHandle << allAtPlusTwitterUserNames()
     }
 
     @Unroll
-    def "should check that twitter username is alphanumeric or underscore"() {
+    def "should check that twitter username #username is alphanumeric or underscore"() {
         expect:
         alphanumericOrUnderscore.matchesAllOf(username)
 
         where:
-        tag << allTwitterUsersTags()
-        username = tag.substring(1)
+        atPlusTwitterHandle << allAtPlusTwitterUserNames()
+        username = atPlusTwitterHandle.substring(1)
     }
 
-    private List<String> allTwitterUsersTags() {
+    private List<String> allAtPlusTwitterUserNames() {
         jsonEntries.findAll{ it.twitter != null }
                 .twitter
     }

--- a/src/test/groovy/com/jvm_bloggers/core/social/twitter/TweetContentGeneratorSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/social/twitter/TweetContentGeneratorSpec.groovy
@@ -6,7 +6,6 @@ import com.jvm_bloggers.entities.blog.BlogType
 import com.jvm_bloggers.entities.blog_post.BlogPost
 import com.jvm_bloggers.entities.newsletter_issue.NewsletterIssue
 import com.jvm_bloggers.utils.NowProvider
-import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -140,24 +139,6 @@ class TweetContentGeneratorSpec extends Specification {
         def company = /@company/
         def companyBlogs = (tweetContent =~ /$company/)
         assert companyBlogs.count == 1
-    }
-
-    @Ignore // This won't happen until we increase length of base template for tweet messages
-    def "Should not add the second personal twitter handle if message is too long"() {
-        given:
-        NewsletterIssue issue = NewsletterIssue
-                .builder()
-                .issueNumber(ISSUE_NUMBER)
-                .heading("issue heading")
-                .blogPosts(postsWithLongHandles())
-                .build()
-
-        when:
-        String tweetContent = contentGenerator.generateTweetContent(issue)
-
-        then:
-        def handles = /.*@veryLongPersonalHandle\d{1} i @veryLongCompanyHandle\d{1}.*/
-        tweetContent ==~ /$handles/
     }
 
     @Unroll


### PR DESCRIPTION
Resolves #463

Since twitter messages are increased to 280 chars, there is no need for shorter message template and  template for `N` messages.