### PR TITLE
Introduce ObjectMother class for test data generation

### DIFF
--- a/src/test/groovy/com/jvm_bloggers/ObjectMother.groovy
+++ b/src/test/groovy/com/jvm_bloggers/ObjectMother.groovy
@@ -1,0 +1,38 @@
+package com.jvm_bloggers
+
+import com.jvm_bloggers.entities.blog.Blog
+import com.jvm_bloggers.entities.blog_post.BlogPost
+
+import java.time.LocalDateTime
+
+import static com.jvm_bloggers.entities.blog.BlogType.PERSONAL
+
+class ObjectMother {
+
+    static Blog aBlog(Map params = [:]) {
+        String id = UUID.randomUUID().toString()
+        [
+                bookmarkableId    : "bookmarkableId $id".subSequence(0,29),
+                author            : 'author',
+                rss               : "rss $id",
+                url               : "url $id",
+                dateAdded         : LocalDateTime.now(),
+                blogType          : PERSONAL,
+                active            : true,
+                moderationRequired: false,
+                twitter           : '@blogging'
+        ] + params as Blog
+    }
+
+    static BlogPost aBlogPost(Map params = [:]) {
+        String id = UUID.randomUUID().toString()
+        [
+                publishedDate   : LocalDateTime.now(),
+                blog            : aBlog(),
+                title           : "title $id",
+                url             : "url $id",
+                approved        : true,
+                description     : "Example description"
+        ] + params as BlogPost
+    }
+}

--- a/src/test/groovy/com/jvm_bloggers/ObjectMother.groovy
+++ b/src/test/groovy/com/jvm_bloggers/ObjectMother.groovy
@@ -14,8 +14,8 @@ class ObjectMother {
         [
                 bookmarkableId    : "bookmarkableId $id".subSequence(0,29),
                 author            : 'author',
-                rss               : "rss $id",
-                url               : "url $id",
+                rss               : "http://example.com/feed/$id",
+                url               : "http://example.com/$id",
                 dateAdded         : LocalDateTime.now(),
                 blogType          : PERSONAL,
                 active            : true,
@@ -30,7 +30,7 @@ class ObjectMother {
                 publishedDate   : LocalDateTime.now(),
                 blog            : aBlog(),
                 title           : "title $id",
-                url             : "url $id",
+                url             : "http://example.com/posts/$id",
                 approved        : true,
                 description     : "Example description"
         ] + params as BlogPost

--- a/src/test/groovy/com/jvm_bloggers/entities/blog/BlogSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/entities/blog/BlogSpec.groovy
@@ -1,9 +1,10 @@
 package com.jvm_bloggers.entities.blog
 
-import com.jvm_bloggers.utils.NowProvider
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
+import static com.jvm_bloggers.ObjectMother.aBlog
 
 @Subject(Blog)
 class BlogSpec extends Specification {
@@ -11,15 +12,7 @@ class BlogSpec extends Specification {
     @Unroll
     def "Should return approvedValue equal to #expectedInitialApprovedValue when moderationRequiredValue is #moderationRequiredValue"() {
         given:
-        Blog blog = Blog.builder()
-            .bookmarkableId("john-doe")
-            .author("John Doe")
-            .rss("http://john-doe.com/feed/")
-            .url("url")
-            .dateAdded(new NowProvider().now())
-            .blogType(BlogType.PERSONAL)
-            .moderationRequired(moderationRequiredValue)
-            .build()
+        Blog blog = aBlog(moderationRequired: moderationRequiredValue)
 
         when:
         Boolean approvedValue = blog.getInitialApprovedValue()


### PR DESCRIPTION
that generates common data for Blog and BlogPost test objects. Easy data customization is allowed via passing an optional Map parameter to factory methods.

Example usage shown on two tests: BlogPostRepositorySpec and BlogSpec