### PR TITLE
Refactor tests into Object Mother pattern for test data generation

### DIFF
--- a/src/test/groovy/com/jvm_bloggers/domain/query/blog_post_for_listing/BlogPostForListingQuerySpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/domain/query/blog_post_for_listing/BlogPostForListingQuerySpec.groovy
@@ -9,9 +9,8 @@ import org.springframework.data.domain.PageRequest
 import spock.lang.Specification
 import spock.lang.Subject
 
-import static com.jvm_bloggers.entities.blog.BlogType.PERSONAL
-import static java.time.LocalDateTime.now
-import static java.util.UUID.randomUUID
+import static com.jvm_bloggers.ObjectMother.aBlog
+import static com.jvm_bloggers.ObjectMother.aBlogPost
 
 @Subject(BlogPostForListingQuery)
 class BlogPostForListingQuerySpec  extends Specification {
@@ -24,7 +23,6 @@ class BlogPostForListingQuerySpec  extends Specification {
 
     def "Should query blog by code"() {
         given:
-        Long blogId = 1L
         String code = "someCode"
         Blog blog = aBlog()
         blogRepository.findByBookmarkableId(code) >> Option.of(blog)
@@ -34,7 +32,7 @@ class BlogPostForListingQuerySpec  extends Specification {
 
         then:
         result.isDefined()
-        result.get() == blogId
+        result.get() == blog.id
     }
 
     def "Should transform Blog to BlogDisplayDetails"() {
@@ -57,46 +55,17 @@ class BlogPostForListingQuerySpec  extends Specification {
     def "Should query posts by blog id"() {
         given:
         Long blogId = 1L
-        Blog blog = aBlog()
-        List<BlogPost> blogPosts = [
-                aBlogPost(blog),
-                aBlogPost(blog),
-                aBlogPost(blog),
-                aBlogPost(blog),
-                aBlogPost(blog),
-                aBlogPost(blog)
-        ]
+        List<BlogPost> blogPosts = [aBlogPost()] * 6
+
         blogPostRepository.findByBlogIdAndApprovedTrueOrderByPublishedDateDesc(blogId, PageRequest.of(0, 10)) >> blogPosts
 
         when:
         List<BlogPostForListing> result = blogPostForListingQuery.findBlogPosts(blogId, 0, 10).toJavaList()
 
         then:
-        result.size() == 6
+        result.size() == blogPosts.size()
         result[0].uid == blogPosts[0].uid
         result[0].title == blogPosts[0].title
         result[0].publishedDate == blogPosts[0].publishedDate
-    }
-
-    private Blog aBlog() {
-        new Blog.BlogBuilder()
-                .url(randomUUID().toString())
-                .id(1)
-                .bookmarkableId(randomUUID().toString())
-                .rss(randomUUID().toString())
-                .dateAdded(now())
-                .author(randomUUID().toString())
-                .blogType(PERSONAL)
-                .build()
-    }
-
-    private BlogPost aBlogPost(final Blog blog) {
-        return BlogPost.builder()
-                .publishedDate(now())
-                .approved(true)
-                .blog(blog)
-                .title(randomUUID().toString())
-                .url(randomUUID().toString())
-                .build()
     }
 }

--- a/src/test/groovy/com/jvm_bloggers/entities/blog/BlogRepositorySpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/entities/blog/BlogRepositorySpec.groovy
@@ -2,16 +2,16 @@ package com.jvm_bloggers.entities.blog
 
 import com.jvm_bloggers.SpringContextAwareSpecification
 import com.jvm_bloggers.entities.blog.projections.BlogStatisticsProjection
-import com.jvm_bloggers.entities.blog_post.BlogPost
 import com.jvm_bloggers.entities.blog_post.BlogPostRepository
 import io.vavr.collection.List
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
 import spock.lang.Subject
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-
+import static java.time.LocalDate.now as today
+import static java.time.LocalDateTime.now
+import static com.jvm_bloggers.ObjectMother.aBlog
+import static com.jvm_bloggers.ObjectMother.aBlogPost
 import static com.jvm_bloggers.entities.blog.BlogType.PERSONAL
 
 class BlogRepositorySpec extends SpringContextAwareSpecification {
@@ -25,25 +25,28 @@ class BlogRepositorySpec extends SpringContextAwareSpecification {
 
     def "Should return blog statistics"() {
         given:
-        Blog pBlog1 = aBlog(1, PERSONAL)
-        Blog pBlog2 = aBlog(2, PERSONAL)
-        Blog pBlog3 = aBlog(3, PERSONAL, false)
+        Blog pBlog1 = blogRepository.save(aBlog(blogType:  PERSONAL))
+        Blog pBlog2 = blogRepository.save(aBlog(blogType:  PERSONAL))
+        Blog pBlog3 = blogRepository.save(aBlog(blogType:  PERSONAL, active: false))
 
-        aBlogPost(1, LocalDateTime.now(), pBlog1)
-        aBlogPost(2, LocalDateTime.now().minusMonths(1), pBlog1)
-        aBlogPost(3, LocalDateTime.now().minusMonths(2), pBlog1)
-        aBlogPost(4, LocalDateTime.now().minusMonths(3).minusDays(1), pBlog1)
-        aBlogPost(5, LocalDateTime.now().minusMonths(3).plusDays(1), pBlog1)
-        aBlogPost(6, LocalDateTime.now().minusMonths(5), pBlog1)
-        aBlogPost(7, LocalDateTime.now().minusMonths(6).minusDays(1), pBlog1)
-        aBlogPost(8, LocalDateTime.now().minusMonths(6).plusDays(2), pBlog1)
-        aBlogPost(9, LocalDateTime.now().minusMonths(6), pBlog3)
-        aBlogPost(10, LocalDateTime.now().minusMonths(6).plusDays(1), pBlog2)
+        blogPostRepository.with {
+            save(aBlogPost(publishedDate: now(), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(1), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(2), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(3).minusDays(1), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(3).plusDays(1), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(5), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(6).minusDays(1), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(6).plusDays(2), blog: pBlog1))
+            save(aBlogPost(publishedDate: now().minusMonths(6), blog: pBlog3))
+            save(aBlogPost(publishedDate: now().minusMonths(6).plusDays(1), blog: pBlog2))
+        }
+
 
         when:
         List<BlogStatisticsProjection> result = blogRepository.findBlogStatistics(
-                LocalDate.now().minusMonths(3).atStartOfDay(),
-                LocalDate.now().minusMonths(6).atStartOfDay(),
+                today().minusMonths(3).atStartOfDay(),
+                today().minusMonths(6).atStartOfDay(),
                 PERSONAL,
                 PageRequest.of(0, 10))
 
@@ -53,29 +56,5 @@ class BlogRepositorySpec extends SpringContextAwareSpecification {
         result.get(0).secondCount == 7
         result.get(1).firstCount == 0
         result.get(1).secondCount == 1
-    }
-
-    private Blog aBlog(int index, BlogType blogType, boolean active = true) {
-        return blogRepository.save(
-                Blog.builder()
-                        .bookmarkableId("bookmarkableId $index")
-                        .author("author")
-                        .rss("rss $index")
-                        .url("url $index")
-                        .dateAdded(LocalDateTime.now())
-                        .blogType(blogType)
-                        .active(active)
-                        .moderationRequired(false)
-                        .build())
-    }
-
-    private BlogPost aBlogPost(int index, LocalDateTime publishedDate, Blog blog) {
-        return blogPostRepository.save(BlogPost.builder()
-                .publishedDate(publishedDate)
-                .blog(blog)
-                .title("title $index")
-                .url("url $index")
-                .approved(true)
-                .build())
     }
 }

--- a/src/test/groovy/com/jvm_bloggers/entities/blog_post/BlogPostSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/entities/blog_post/BlogPostSpec.groovy
@@ -1,7 +1,5 @@
 package com.jvm_bloggers.entities.blog_post
 
-import com.jvm_bloggers.entities.blog.Blog
-import com.jvm_bloggers.entities.blog.BlogType
 import com.jvm_bloggers.utils.NowProvider
 import spock.lang.Specification
 import spock.lang.Subject
@@ -10,6 +8,9 @@ import spock.lang.Unroll
 import java.time.LocalDateTime
 import java.time.Month
 
+import static com.jvm_bloggers.ObjectMother.aBlogPost
+import static java.time.LocalDateTime.of
+
 @Subject(BlogPost)
 class BlogPostSpec extends Specification {
     private static final Boolean NOT_MODERATED = null
@@ -17,7 +18,7 @@ class BlogPostSpec extends Specification {
     @Unroll
     def "Should return \"#expectedState\" state when approved is #approved "() {
         given:
-        BlogPost blogPost = createBlogPost(approved)
+        BlogPost blogPost = aBlogPost(approved: approved)
 
         when:
         String approvalState = blogPost.getApprovalState()
@@ -35,7 +36,7 @@ class BlogPostSpec extends Specification {
     @Unroll
     def "Should return #expected when isModerated called for post with approved = #approved"() {
         given:
-        BlogPost blogPost = createBlogPost(approved)
+        BlogPost blogPost = aBlogPost(approved: approved)
 
         when:
         boolean isModerated = blogPost.isModerated()
@@ -54,7 +55,7 @@ class BlogPostSpec extends Specification {
     def "Should return whether post is going in newsletter"() {
 
         given:
-        BlogPost blogPost = createBlogPost(approved, postApprovedDate)
+        BlogPost blogPost = aBlogPost(approved: approved, approvedDate: postApprovedDate)
 
         when:
         boolean inNewsletter = blogPost.isGoingInNewsletter(lastNewsletterDate)
@@ -63,15 +64,15 @@ class BlogPostSpec extends Specification {
         inNewsletter == expected
 
         where:
-        approved | postApprovedDate                                || lastNewsletterDate                              || expected
-        true     | LocalDateTime.of(2016, Month.MARCH, 20, 12, 00) || LocalDateTime.of(2016, Month.MARCH, 19, 12, 00) || true
-        true     | LocalDateTime.of(2016, Month.MARCH, 20, 12, 00) || LocalDateTime.of(2016, Month.MARCH, 21, 12, 00) || false
-        false    | LocalDateTime.of(2016, Month.MARCH, 20, 12, 00) || LocalDateTime.of(2016, Month.MARCH, 19, 12, 00) || false
+        approved | postApprovedDate                  || lastNewsletterDate                || expected
+        true     | of(2016, Month.MARCH, 20, 12, 00) || of(2016, Month.MARCH, 19, 12, 00) || true
+        true     | of(2016, Month.MARCH, 20, 12, 00) || of(2016, Month.MARCH, 21, 12, 00) || false
+        false    | of(2016, Month.MARCH, 20, 12, 00) || of(2016, Month.MARCH, 19, 12, 00) || false
     }
 
     def "Should approve post"() {
         given:
-        BlogPost blogPost = createBlogPost(NOT_MODERATED)
+        BlogPost blogPost = aBlogPost(approved: NOT_MODERATED)
         LocalDateTime approvedDate = new NowProvider().now()
 
         when:
@@ -82,35 +83,9 @@ class BlogPostSpec extends Specification {
         blogPost.approvedDate == approvedDate
     }
 
-    private BlogPost createBlogPost(final Boolean approved) {
-        createBlogPost(approved,
-            Boolean.TRUE == approved
-                ? new NowProvider().now()
-                : null)
-    }
-
-    private BlogPost createBlogPost(final Boolean approved, LocalDateTime postApprovedDate) {
-
-        return BlogPost.builder()
-            .approved(approved)
-            .title("title")
-            .url("url")
-            .publishedDate(new NowProvider().now())
-            .approvedDate(postApprovedDate)
-            .blog(Blog.builder()
-            .bookmarkableId("bookmarkableId")
-            .blogType(BlogType.PERSONAL)
-            .author("author")
-            .rss("rss")
-            .url("url")
-            .dateAdded(new NowProvider().now())
-            .build())
-            .build()
-    }
-
     def "Should create BlogPost with random uid"() {
         when:
-        BlogPost blogPost = createBlogPost(false)
+        BlogPost blogPost = aBlogPost(approved: false)
 
         then:
         blogPost.uid != null

--- a/src/test/groovy/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepositorySpecBase.groovy
+++ b/src/test/groovy/com/jvm_bloggers/entities/newsletter_issue/NewsletterIssueRepositorySpecBase.groovy
@@ -1,16 +1,15 @@
 package com.jvm_bloggers.entities.newsletter_issue
 
-import com.google.common.collect.Lists
 import com.jvm_bloggers.SpringContextAwareSpecification
 import com.jvm_bloggers.entities.blog.Blog
 import com.jvm_bloggers.entities.blog.BlogRepository
-import com.jvm_bloggers.entities.blog.BlogType
 import com.jvm_bloggers.entities.blog_post.BlogPost
 import com.jvm_bloggers.entities.blog_post.BlogPostRepository
 import com.jvm_bloggers.utils.NowProvider
 import org.springframework.beans.factory.annotation.Autowired
 
-import java.time.LocalDateTime
+import static com.jvm_bloggers.ObjectMother.aBlog
+import static com.jvm_bloggers.ObjectMother.aBlogPost
 
 class NewsletterIssueRepositorySpecBase extends SpringContextAwareSpecification {
 
@@ -24,29 +23,9 @@ class NewsletterIssueRepositorySpecBase extends SpringContextAwareSpecification 
     BlogPostRepository blogPostRepository
 
     protected List<Blog> prepareBlogs() {
-        Blog blog1 = Blog.builder()
-                .active(true)
-                .author("John Doe")
-                .blogType(BlogType.PERSONAL)
-                .dateAdded(LocalDateTime.now())
-                .bookmarkableId("bookmarkableId-1")
-                .rss("http://example.com/rss")
-                .url("http://example.com")
-                .moderationRequired(false)
-                .build()
-        blogRepository.save(blog1)
-        Blog blog2 = Blog.builder()
-                .active(true)
-                .author("Kate Ryan")
-                .blogType(BlogType.COMPANY)
-                .dateAdded(LocalDateTime.now())
-                .bookmarkableId("bookmarkableId-2")
-                .rss("http://another-url.com/rss")
-                .url("http://another-url.com")
-                .moderationRequired(false)
-                .build()
-        blogRepository.save(blog2)
-        return Lists.asList(blog1, blog2)
+        [aBlog(author: 'John Doe'), aBlog(author: 'Kate Ryan')].each {
+            blogRepository.save(it)
+        }
     }
 
     protected List<BlogPost> prepareBlogPosts(Blog blog1, Blog blog2) {
@@ -54,19 +33,14 @@ class NewsletterIssueRepositorySpecBase extends SpringContextAwareSpecification 
         BlogPost blogPost2 = createAndSaveBlogPost(blog2, "http://abc.pl/2")
         BlogPost blogPost3 = createAndSaveBlogPost(blog2, "http://abc.pl/3")
         BlogPost blogPost4 = createAndSaveBlogPost(blog2, "http://abc.pl/4")
-        return Lists.newArrayList(blogPost1, blogPost2, blogPost3, blogPost4)
+        return [blogPost1, blogPost2, blogPost3, blogPost4]
     }
 
     protected BlogPost createAndSaveBlogPost(Blog blog, String url) {
-        BlogPost blogPost = BlogPost
-                .builder()
-                .approved(true)
-                .blog(blog)
-                .description("Example description")
-                .publishedDate(LocalDateTime.now())
-                .title("Example title")
-                .url(url)
-                .build()
+        BlogPost blogPost = aBlogPost(
+                blog: blog,
+                url: url
+        )
         blogPostRepository.save(blogPost)
         return blogPost
     }


### PR DESCRIPTION
Reusing ObjectMother in tests that were building Blog and BlogPost data on their own.

for NewsletterIssueRepositorySpecBase.groovy : I don't think it's a good idea to abstract test data generation away to a superclass, but I am not changing it now. A much better approach would be to explicitly generate this data in test methods or delegate this responsibility to the ObjectMother.