### PR TITLE
Add setting moderation enabled for blogs from medium, #574

### DIFF
--- a/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
+++ b/src/main/java/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdater.java
@@ -85,9 +85,14 @@ public class BloggersDataUpdater {
             .dateAdded(nowProvider.now())
             .blogType(bloggerEntry.getBlogType())
             .active(true)
-            .moderationRequired(bloggerEntry.getBlogType() != PERSONAL)
+            .moderationRequired(isModerationRequired(bloggerEntry))
             .build();
         blogRepository.save(newBlog);
         return UpdateStatus.CREATED;
+    }
+
+    private boolean isModerationRequired(BloggerEntry bloggerEntry) {
+        return bloggerEntry.getBlogType() != PERSONAL
+            || bloggerEntry.getRss() != null && bloggerEntry.getRss().contains("//medium.com");
     }
 }

--- a/src/test/groovy/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdaterSpec.groovy
+++ b/src/test/groovy/com/jvm_bloggers/core/data_fetching/blogs/BloggersDataUpdaterSpec.groovy
@@ -152,6 +152,41 @@ class BloggersDataUpdaterSpec extends Specification {
         statistics.getUpdated() == 1
     }
 
+    def "Should set moderation required if address is from medium"() {
+        given:
+        String rssFromMedium = "https://medium.com/feed/@user"
+        String bookmarkableId = 'bookmarkableId-2207'
+        BloggerEntry entry = buildBloggerEntry(bookmarkableId, 'blog', rssFromMedium, 'page', 'twitter', PERSONAL)
+        blogRepository.findByBookmarkableId(bookmarkableId) >> Option.none()
+        BloggersData bloggers = buildBloggersData(entry)
+
+        when:
+        UpdateStatistic statistics = bloggersDataUpdater.updateData(bloggers)
+
+        then:
+        1 * blogRepository.save({
+            it.moderationRequired == true
+        })
+        statistics.getCreated() == 1
+    }
+
+    def "Should set moderation not required if blog is personal and not from medium"() {
+        given:
+        String bookmarkableId = 'bookmarkableId-2207'
+        BloggerEntry entry = buildBloggerEntry(bookmarkableId, 'blog', RSS_OF_VALID_BLOG, 'page', 'twitter', PERSONAL)
+        blogRepository.findByBookmarkableId(bookmarkableId) >> Option.none()
+        BloggersData bloggers = buildBloggersData(entry)
+
+        when:
+        UpdateStatistic statistics = bloggersDataUpdater.updateData(bloggers)
+
+        then:
+        1 * blogRepository.save({
+            it.moderationRequired == false
+        })
+        statistics.getCreated() == 1
+    }
+
     def buildBloggersData(BloggerEntry bloggerEntry) {
         BloggersData bloggersData = new BloggersData()
         bloggersData.getBloggers().add(bloggerEntry)


### PR DESCRIPTION
I'm not sure if this brute-force in BloggersDataUpdater#isModerationRequired is a good idea.

Maybe create version with "banned list" in json file? It's not too complicated for this simple issue?