### PR TITLE
Switch caddy Docker image from latest to 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     depends_on:
       - jvm-bloggers-db
   jvm-bloggers-proxy:
-    image: caddy/caddy:latest
+    image: caddy/caddy:2
     container_name: jvm-bloggers-proxy
     command: caddy reverse-proxy --from jvm-bloggers.com --to jvm-bloggers-core:8080
     volumes:


### PR DESCRIPTION
2.0.0 has been released: https://github.com/caddyserver/caddy/releases/tag/v2.0.0
There is a dedicated tag for 2.x which should be more pertinent over time (in the context of backward compatibility):
https://hub.docker.com/_/caddy?tab=tags