### PR TITLE
Removing szimano.org (dead link)

### DIFF
--- a/src/main/resources/blogs/bloggers.json
+++ b/src/main/resources/blogs/bloggers.json
@@ -121,12 +121,6 @@
       "twitter": "@pawelstawicki"
     },
     {
-      "bookmarkableId": "szimano",
-      "name": "Tomek Szymański",
-      "rss": "http://szimano.org/feed/",
-      "twitter": "@szimano"
-    },
-    {
       "bookmarkableId": "andrzej-ludwikowski",
       "name": "Andrzej Ludwikowski",
       "rss": "http://www.ludwikowski.info/feeds/posts/default"


### PR DESCRIPTION
Redirects to LinkedIn