### PR TITLE
Fixes podcasts file validation

### DIFF
--- a/src/main/resources/blogs/podcasts.json
+++ b/src/main/resources/blogs/podcasts.json
@@ -71,7 +71,7 @@
             "twitter": "@bottega_it"
         },
         {
-            "bookmarkableId": "bITcast",
+            "bookmarkableId": "b-it-cast",
             "name": "Bydgoszcz IT Podcast",
             "rss": "http://bydgoszcz.jug.pl/feed/podcast",
             "twitter": "@BydgoszczJUG"


### PR DESCRIPTION
PR: #636 broke the `JsonBlogsDataFileValidationSpec` test (exactly the one checking `should check that bookmarkable ID #id is lower-case, alphanumeric or hyphen`). For the quick look, the fix is easy, just rename `"bookmarkableId": "bITcast"` to e.g. `"bookmarkableId": "b-it-cast".

This issue was also addressed in the #642 