### PR TITLE
Cognifide rebranded to Wunderman Thompson Technology

### DIFF
--- a/src/main/resources/blogs/companies.json
+++ b/src/main/resources/blogs/companies.json
@@ -163,10 +163,10 @@
       "twitter": "@nexocode_com"
     },
     {
-      "bookmarkableId": "cogtech",
-      "name": "Cognifide Tech",
-      "rss": "https://tech.cognifide.com/rss.xml",
-      "twitter": "@Cognifide"
+      "bookmarkableId": "wttech",
+      "name": "Wunderman Thompson Tech Hub",
+      "rss": "https://wttech.blog/rss.xml",
+      "twitter": "@WunThompsonTECH"
     }
   ]
 }


### PR DESCRIPTION
Hi,
Cognifide has recently rebranded to Wunderman Thompson Technology and we have redesigned blog page under the new address.