### PR TITLE
Updated allegro blog RSS address

### DIFF
--- a/src/main/resources/blogs/bloggers.json
+++ b/src/main/resources/blogs/bloggers.json
@@ -161,7 +161,7 @@
       "twitter": "@tkaczanowski"
     },
     {
-      "bookmarkableId": "jakub-nabrdalik",
+      "bookmarkableId": "jakub-nabrdalik-2",
       "name": "Jakub Nabrdalik",
       "rss": "http://blog.solidcraft.eu/feeds/posts/default",
       "twitter": "@jnabrdalik"

--- a/src/main/resources/blogs/companies.json
+++ b/src/main/resources/blogs/companies.json
@@ -27,7 +27,7 @@
     {
       "bookmarkableId": "allegro-tech",
       "name": "Allegro Tech",
-      "rss": "https://allegro.tech/feed.xml",
+      "rss": "https://blog.allegro.tech/feed.xml",
       "twitter": "@allegrotech"
     },
     {


### PR DESCRIPTION
We'll add a redirect at the old address, but it's better to use the new address directly anyway