### PR TITLE
Removing mmazurek.dev

### DIFF
--- a/src/main/resources/blogs/bloggers.json
+++ b/src/main/resources/blogs/bloggers.json
@@ -1014,12 +1014,6 @@
       "rss": "https://jgardo.dev/feed/"
     },
     {
-      "bookmarkableId": "mateusz-mazurek",
-      "name": "Mateusz Mazurek",
-      "rss": "https://mmazur.eu.org/feed/",
-      "twitter": "@kajzur"
-    },
-    {
       "bookmarkableId": "mateusz-dabrowski",
       "name": "Mateusz Dąbrowski",
       "rss": "http://nullpointerexception.pl/feed/",


### PR DESCRIPTION
Author no longer writes in Java and the last 10 or so articles are abot Python: https://mmazurek.dev/kiedys-programowalem-w-javie-czyli-o-zmianie-jezyka-wiodacego/