### PR TITLE
Remove deprecated jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         gradlePluginPortal()
     }
 
@@ -36,7 +35,6 @@ version = '2.0.0'
 sourceCompatibility = '12'
 
 repositories {
-    jcenter()
     mavenLocal()
     mavenCentral()
 }


### PR DESCRIPTION
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Even thought they decided - under the pressure - to keep it as a read-only
repository "indefinitely".