### PR TITLE
Change konkit.tech feed address

### DIFF
--- a/src/main/resources/blogs/bloggers.json
+++ b/src/main/resources/blogs/bloggers.json
@@ -1201,7 +1201,7 @@
     {
       "bookmarkableId": "konkit-tech",
       "name": "Łukasz Tenerowicz",
-      "rss": "https://konkit.tech/feed",
+      "rss": "https://konkit.tech/index.xml",
       "twitter": "@konkit"
     },
     {


### PR DESCRIPTION
I've changed the blog engine from WP to Hugo, and I would like to ask to change the address here, so I won't have to search for workarounds to set a custom feed address.

URLs of particular posts should remain the same as before, so I hope there won't be any mess here.

Thank you!