### PR TITLE
Fixes ValidatorMessageTranslatorSpec tests

### DIFF
--- a/buildSrc/src/test/groovy/com/jvm_bloggers/validation/ValidatorMessageTranslatorSpec.groovy
+++ b/buildSrc/src/test/groovy/com/jvm_bloggers/validation/ValidatorMessageTranslatorSpec.groovy
@@ -57,7 +57,7 @@ class ValidatorMessageTranslatorSpec extends Specification {
         def result = ValidatorMessageTranslator.translate(Set.of(message1, message2))
 
         then:
-        result.contains("Element '\$.element' violates 'maxItems' rule - 'there must be a maximum of 4 items in the array'\n")
+        result.contains("Element '\$.element' violates 'maxItems' rule - 'there must be a maximum of 4 items in the array'")
         result.contains("Array '\$.array' contains not unique elements!")
     }
 }


### PR DESCRIPTION
* fixes a "small" issue with `ValidatorMessageTranslatorSpec` tests that was making them not so deterministic
* the issue was introduced within #747