### PR TITLE
Update Spring Boot to version 2.7.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'io.vavr:vavr:0.10.4'
     implementation 'org.jsoup:jsoup:1.15.3'
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.1'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.2'
     implementation 'org.json:json:20220924'
     implementation('com.vdurmont:emoji-java:5.1.1') {
         exclude group: 'org.json', module: 'json'
@@ -107,8 +107,8 @@ dependencies {
     implementation 'org.postgresql:postgresql'
     implementation 'org.liquibase:liquibase-core'
     implementation 'com.mattbertolini:liquibase-slf4j:4.1.0'
-    implementation 'org.hibernate:hibernate-search-orm:5.11.10.Final'
-    implementation 'org.hibernate:hibernate-search-engine:5.11.10.Final'
+    implementation 'org.hibernate:hibernate-search-orm:5.11.11.Final'
+    implementation 'org.hibernate:hibernate-search-engine:5.11.11.Final'
 
     // Test dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 plugins {
     id 'org.springframework.boot' version '2.7.5'
-    id 'io.spring.dependency-management' version '1.0.14.RELEASE'
+    id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
     id 'groovy'
     id 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,14 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.7.4"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.7.5"
         classpath "com.bmuschko:gradle-docker-plugin:7.4.0"
         classpath 'com.ofg:uptodate-gradle-plugin:1.6.3'
     }
 }
 
 plugins {
-    id 'org.springframework.boot' version '2.7.4'
+    id 'org.springframework.boot' version '2.7.5'
     id 'io.spring.dependency-management' version '1.0.14.RELEASE'
     id 'java'
     id 'groovy'

--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,14 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.7.5"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.7.6"
         classpath "com.bmuschko:gradle-docker-plugin:7.4.0"
         classpath 'com.ofg:uptodate-gradle-plugin:1.6.3'
     }
 }
 
 plugins {
-    id 'org.springframework.boot' version '2.7.5'
+    id 'org.springframework.boot' version '2.7.6'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
     id 'groovy'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ repositories {
 
 ext {
     wicketVersion = '9.12.0'
-    jerseyVersion = '2.36'
+    jerseyVersion = '2.37'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ docker {
     }
 
     springBootApplication {
-        baseImage = 'eclipse-temurin:17.0.4.1_1-jre-alpine'
+        baseImage = 'eclipse-temurin:17.0.5_8-jre-alpine'
         maintainer = 'Tomasz Dziurko "tdziurko at gmail dottt com"'
         ports = [8080, 8080]
         jvmArgs = ['-Dwicket.ioc.useByteBuddy=true']

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,9 +19,9 @@ repositories {
 dependencies {
     implementation gradleApi()
     implementation 'com.networknt:json-schema-validator:1.0.73'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 
-    testImplementation 'org.spockframework:spock-core:2.2-groovy-3.0'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.13'
     testImplementation 'org.codehaus.groovy:groovy-json:3.0.13'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     implementation gradleApi()
     implementation 'com.networknt:json-schema-validator:1.0.73'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.13'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* bump up Spring Boot version to `2.7.6`
* bump up Gradle wrapper to version `7.6`
* bump up `io.spring.dependency-management` plugin version to `1.1.0`
* bump up `caffeine` to version `3.1.2`
* bump up `hibernate-search` to version `5.11.11.Final`
* bump up `jersey` to version `2.37`
* bump up base Docker image to `eclipse-temurin:17.0.5_8-jre-alpine`

PS. We are a bit blocked to migrate to Spring Boot 3 due to the fact that Wicket is not migrated to `jakarta` yet (when the new Spring Boot is) -> see: https://issues.apache.org/jira/browse/WICKET-6882