### PR TITLE
Add swistak.codes to bloggers.json

### DIFF
--- a/src/main/resources/blogs/bloggers.json
+++ b/src/main/resources/blogs/bloggers.json
@@ -1318,6 +1318,11 @@
       "bookmarkableId": "michal-p-dev-notes",
       "name": "Michał Pawlik",
       "rss": "https://blog.michalp.net/index.xml"
+    },
+    {
+      "bookmarkableId": "swistak-codes",
+      "name": "świstak.codes",
+      "rss": "https://swistak.codes/rss-all/feed.xml"
     }
   ]
 }


### PR DESCRIPTION
My blog is not strictly JVM related, but since it covers very general IT and development topics, I think it could also interest Java/Kotlin devs. 