### PR TITLE
FIX "Fork me on Github" ribbon

### DIFF
--- a/src/main/java/com/jvm_bloggers/frontend/public_area/AbstractFrontendPage.html
+++ b/src/main/java/com/jvm_bloggers/frontend/public_area/AbstractFrontendPage.html
@@ -38,7 +38,7 @@
 
 <body>
 <!--The Main Wrapper-->
-<a href="https://github.com/jvm-bloggers/jvm-bloggers" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 1000" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+<a href="https://github.com/jvm-bloggers/jvm-bloggers" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 1000" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_orange_ff7600.png?resize=149%2C149" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="page">
     <!--
     ========================================================


### PR DESCRIPTION
Currently it looks like that
<img width="630" alt="Screenshot 2023-07-16 at 23 41 47" src="https://github.com/jvm-bloggers/jvm-bloggers/assets/28829503/574c4c25-e711-41cc-a272-5f9be0cc5148">
And after change ribbon is fixed
<img width="740" alt="Screenshot 2023-07-16 at 23 42 17" src="https://github.com/jvm-bloggers/jvm-bloggers/assets/28829503/2f7196d7-7b2a-4949-84d1-2595f8f266f7">
