### PR TITLE
Update expired Slack invite link for JVM Poland

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,5 +77,5 @@ twitter.api:
   retryIntervalSecs: 5
 
 slack:
-  invitation-link: https://join.slack.com/t/jvm-poland/shared_invite/enQtODE2ODgwMzU4NzA2LWUyZTIyZGRiOThjMDQ1NzI0OWVjZDVkZjc0ZjQ4OTZmMGM0NWNlNTQ3OTBhZmI5MGQ5Y2VlMmU1MGE4OGY2NTQ
+  invitation-link: https://join.slack.com/t/jvm-poland/shared_invite/zt-3jnk4d65t-jzAqnPL_Zv2jtge3QqsPbA
 


### PR DESCRIPTION
## Summary
- The Slack invite link on the `/jvm-poland-slack` page was expired and no longer working
- Updated `slack.invitation-link` in `application.yaml` to the new shared invite URL

## Context
Reported on Discord by Krzysztof Ślusarski — the old invite link returns an error when users try to join JVM Poland Slack.